### PR TITLE
feat(docker): add Dockerfile for containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+node_modules
+.next
+.git
+.gitignore
+.beads
+.dolt
+*.db
+.beads-credential-key
+
+# Docs, design, and agent config — not needed in the image
+design/
+docs/
+.agents/
+.claude/
+.codex/
+.github/
+*.md
+LICENSE
+
+# Scripts and global launcher — not needed in container (we run server.js directly)
+scripts/
+bin/
+
+# Misc
+graphify-out/
+.env*
+.DS_Store
+*.pem
+*.tsbuildinfo
+next-env.d.ts
+coverage/
+build/
+out/
+.vercel

--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,7 @@ bin/
 
 # Misc
 graphify-out/
+.venv/
 .env*
 .DS_Store
 *.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ── Builder: install deps and build the Next.js app ──────────────────────────
+ARG NODE_VERSION=26
+FROM node:${NODE_VERSION}-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+# next.config.ts reads git for build metadata; git is unavailable in the
+# container, but it falls back gracefully (badge hides). Override via build args
+# if you want the badge to show a specific build/sha.
+ARG BUILD_NUMBER=""
+ARG BUILD_SHA=""
+ENV BUILD_NUMBER=${BUILD_NUMBER} BUILD_SHA=${BUILD_SHA}
+
+RUN npm run build
+
+# ── Runner: minimal image with only the standalone output ────────────────────
+FROM node:${NODE_VERSION}-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# Run as a non-root user for security
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser  --system --uid 1001 nextjs
+
+# Copy the standalone server, static assets, and public files
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,25 @@
+# ── bd: download prebuilt beads CLI from GitHub releases ───────────────────
+# bd uses embedded Dolt (CGO), so the prebuilt Linux binary is glibc-linked.
+# That's why the runner stage uses Debian slim instead of Alpine (musl).
+ARG BD_VERSION=1.0.4
+ARG NODE_VERSION=26.4.0
+FROM alpine:latest AS bd
+ARG BD_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl tar \
+ && case "$TARGETARCH" in \
+      amd64) ARCH=amd64 ;; \
+      arm64) ARCH=arm64 ;; \
+      *) echo "Unsupported arch: $TARGETARCH"; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/bd.tar.gz \
+      "https://github.com/gastownhall/beads/releases/download/v${BD_VERSION}/beads_${BD_VERSION}_linux_${ARCH}.tar.gz" \
+ && tar -xzf /tmp/bd.tar.gz -C /tmp \
+ && mv /tmp/bd /usr/local/bin/bd \
+ && chmod +x /usr/local/bin/bd \
+ && rm -rf /tmp/*
+
 # ── Builder: install deps and build the Next.js app ──────────────────────────
-ARG NODE_VERSION=26
 FROM node:${NODE_VERSION}-alpine AS builder
 
 WORKDIR /app
@@ -18,8 +38,9 @@ ENV BUILD_NUMBER=${BUILD_NUMBER} BUILD_SHA=${BUILD_SHA}
 
 RUN npm run build
 
-# ── Runner: minimal image with only the standalone output ────────────────────
-FROM node:${NODE_VERSION}-alpine AS runner
+# ── Runner: minimal image with standalone output + bd ───────────────────────
+# Debian slim (not Alpine) because the prebuilt bd binary is glibc-linked.
+FROM node:${NODE_VERSION}-slim AS runner
 
 WORKDIR /app
 
@@ -28,13 +49,16 @@ ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
 # Run as a non-root user for security
-RUN addgroup --system --gid 1001 nodejs \
- && adduser  --system --uid 1001 nextjs
+RUN groupadd --system --gid 1001 nodejs \
+ && useradd  --system --uid 1001 --gid nodejs nextjs
 
 # Copy the standalone server, static assets, and public files
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+# Copy the prebuilt bd CLI into the image
+COPY --from=bd --chown=nextjs:nodejs /usr/local/bin/bd /usr/local/bin/bd
 
 USER nextjs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,32 @@
 # ── bd: download prebuilt beads CLI from GitHub releases ───────────────────
 # bd uses embedded Dolt (CGO), so the prebuilt Linux binary is glibc-linked.
 # That's why the runner stage uses Debian slim instead of Alpine (musl).
-ARG BD_VERSION=1.0.4
+# Release filenames use Docker's TARGETARCH values (amd64/arm64) verbatim.
+ARG BD_VERSION=1.1.0
 ARG NODE_VERSION=26.4.0
-FROM alpine:latest AS bd
+FROM alpine:3.22 AS bd
 ARG BD_VERSION
 ARG TARGETARCH
-RUN apk add --no-cache curl tar \
- && case "$TARGETARCH" in \
-      amd64) ARCH=amd64 ;; \
-      arm64) ARCH=arm64 ;; \
-      *) echo "Unsupported arch: $TARGETARCH"; exit 1 ;; \
-    esac \
- && curl -fsSL -o /tmp/bd.tar.gz \
-      "https://github.com/gastownhall/beads/releases/download/v${BD_VERSION}/beads_${BD_VERSION}_linux_${ARCH}.tar.gz" \
- && tar -xzf /tmp/bd.tar.gz -C /tmp \
- && mv /tmp/bd /usr/local/bin/bd \
- && chmod +x /usr/local/bin/bd \
- && rm -rf /tmp/*
+ADD https://github.com/gastownhall/beads/releases/download/v${BD_VERSION}/beads_${BD_VERSION}_linux_${TARGETARCH}.tar.gz /tmp/bd.tar.gz
+RUN tar -xzf /tmp/bd.tar.gz -C /tmp && mv /tmp/bd /usr/local/bin/bd
+
+# ── Eleventy: self-contained tree for the showcase publisher ─────────────────
+# The app locates node_modules/@11ty/eleventy/cmd.cjs by scanning the
+# filesystem (lib/showcase/generate.ts) — it is deliberately never imported, so
+# Next's standalone output tracing does not include it. Install it with its
+# full dependency tree here and copy it into the runner below.
+# Keep the version in sync with package.json.
+FROM node:${NODE_VERSION}-alpine AS eleventy
+WORKDIR /eleventy
+RUN npm install --no-save @11ty/eleventy@3.1.6
 
 # ── Builder: install deps and build the Next.js app ──────────────────────────
 FROM node:${NODE_VERSION}-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
 
 COPY . .
 
@@ -34,7 +35,10 @@ COPY . .
 # if you want the badge to show a specific build/sha.
 ARG BUILD_NUMBER=""
 ARG BUILD_SHA=""
-ENV BUILD_NUMBER=${BUILD_NUMBER} BUILD_SHA=${BUILD_SHA}
+
+# Standalone output is opt-in (see next.config.ts) so local `next start` flows
+# keep the default output.
+ENV NEXT_STANDALONE=1
 
 RUN npm run build
 
@@ -50,19 +54,32 @@ ENV HOSTNAME=0.0.0.0
 ENV HOME=/home/nextjs
 ENV XDG_CONFIG_HOME=/home/nextjs/.config
 
-# Run as a non-root user for security and give bd a real home/config dir
+# Run as a non-root user for security and give bd a real home/config dir.
+# The home/config dirs are world-writable so `docker run --user <uid>:<gid>`
+# (the README's fix for mounted-volume permission errors) can still write app
+# settings and bd state — Debian's HOME_MODE 0700 would otherwise block any
+# uid other than 1001 from even traversing /home/nextjs.
 RUN groupadd --system --gid 1001 nodejs \
  && useradd --system --uid 1001 --gid nodejs --create-home --home-dir /home/nextjs nextjs \
  && mkdir -p /home/nextjs/.config \
- && chown -R nextjs:nodejs /home/nextjs
+ && chown -R nextjs:nodejs /home/nextjs \
+ && chmod 0777 /home/nextjs /home/nextjs/.config
 
-# Copy the standalone server, static assets, and public files
+# Copy the standalone server, static assets, and public files.
+# Next's file tracing puts a PARTIAL @11ty/eleventy (cmd.cjs without its deps)
+# into the standalone node_modules; it would shadow the complete /node_modules
+# tree below (eleventyBin() checks cwd first), so drop it.
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+RUN rm -rf ./node_modules/@11ty
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 # Copy the prebuilt bd CLI into the image
 COPY --from=bd --chown=nextjs:nodejs /usr/local/bin/bd /usr/local/bin/bd
+
+# Eleventy for the showcase publisher. /node_modules sits on eleventyBin()'s
+# upward search path and never collides with the standalone node_modules.
+COPY --from=eleventy --chown=nextjs:nodejs /eleventy/node_modules /node_modules
 
 USER nextjs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,14 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
+ENV HOME=/home/nextjs
+ENV XDG_CONFIG_HOME=/home/nextjs/.config
 
-# Run as a non-root user for security
+# Run as a non-root user for security and give bd a real home/config dir
 RUN groupadd --system --gid 1001 nodejs \
- && useradd  --system --uid 1001 --gid nodejs nextjs
+ && useradd --system --uid 1001 --gid nodejs --create-home --home-dir /home/nextjs nextjs \
+ && mkdir -p /home/nextjs/.config \
+ && chown -R nextjs:nodejs /home/nextjs
 
 # Copy the standalone server, static assets, and public files
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./

--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ docker run -d -p 3000:3000 \
   bead-me-up-scotty
 ```
 
-On Linux, if `bd` fails with permission errors writing to the mounted `.beads`
-directory, run as your host user: `--user $(id -u):$(id -g)`.
+The container runs as a non-root `nextjs` user with `HOME=/home/nextjs` and
+`XDG_CONFIG_HOME=/home/nextjs/.config`, so `bd` and app settings have a valid
+runtime config directory. On Linux, if `bd` fails with permission errors writing
+to the mounted `.beads` directory, run as your host user: `--user $(id -u):$(id -g)`.
 
 ## Install globally
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,24 @@ docker run -d -p 3000:3000 \
 The container runs as a non-root `nextjs` user with `HOME=/home/nextjs` and
 `XDG_CONFIG_HOME=/home/nextjs/.config`, so `bd` and app settings have a valid
 runtime config directory. On Linux, if `bd` fails with permission errors writing
-to the mounted `.beads` directory, run as your host user: `--user $(id -u):$(id -g)`.
+to the mounted `.beads` directory, run as your host user: `--user $(id -u):$(id -g)`
+(the config dirs are world-writable, so settings keep working). Settings live
+inside the container, so they are lost when it is recreated — bind-mount the
+config dir to keep them:
+
+```bash
+-v "$HOME/.config/bead-me-up-scotty:/home/nextjs/.config/bead-me-up-scotty"
+```
+
+Container limitations:
+
+- The image has no `git`, so Dolt remote sync (`refs/dolt/data`) and `bd init`
+  don't work inside it — run those on the host. UI edits (create/update/close)
+  work fine; they just won't auto-push until you sync from the host.
+- **Refine with AI** shells out to the Claude Code CLI, which isn't bundled;
+  the button shows an error in the container.
+- The bundled `bd` version is pinned in the Dockerfile (`ARG BD_VERSION`);
+  override with `--build-arg BD_VERSION=<version>` to match your host.
 
 ## Install globally
 

--- a/README.md
+++ b/README.md
@@ -113,28 +113,20 @@ docker build -t bead-me-up-scotty .
 docker run -p 3000:3000 bead-me-up-scotty      # → http://localhost:3000
 ```
 
-This runs in **demo mode** by default (no `bd` binary inside the container).
-To use real data, mount your project directory and point `BEADS_REPO` at it:
+The image includes the `bd` CLI, so real data works out of the box — just
+mount your project directory and point `BEADS_REPO` at it:
 
 ```bash
 BEADS_REPO=/path/to/project
-docker run -p 3000:3000 \
+docker run -d -p 3000:3000 \
   --name beads_ui \
   -v $BEADS_REPO:/data \
   -e BEADS_REPO=/data \
   bead-me-up-scotty
 ```
 
-If `bd` is on your host `PATH`, you can also mount the binary and point to it
-with `BD_BIN`:
-
-```bash
-docker run -p 3000:3000 \
-  -v /path/to/project:/data \
-  -v /usr/local/bin/bd:/usr/local/bin/bd \
-  -e BEADS_REPO=/data \
-  bead-me-up-scotty
-```
+On Linux, if `bd` fails with permission errors writing to the mounted `.beads`
+directory, run as your host user: `--user $(id -u):$(id -g)`.
 
 ## Install globally
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,36 @@ npm run dev            # http://localhost:3000
 Set the human actor / allowlist, repo path, and theme in **Settings** (stored
 under your OS config dir, not in beads).
 
+### Docker
+
+```bash
+docker build -t bead-me-up-scotty .
+docker run -p 3000:3000 bead-me-up-scotty      # → http://localhost:3000
+```
+
+This runs in **demo mode** by default (no `bd` binary inside the container).
+To use real data, mount your project directory and point `BEADS_REPO` at it:
+
+```bash
+BEADS_REPO=/path/to/project
+docker run -p 3000:3000 \
+  --name beads_ui \
+  -v $BEADS_REPO:/data \
+  -e BEADS_REPO=/data \
+  bead-me-up-scotty
+```
+
+If `bd` is on your host `PATH`, you can also mount the binary and point to it
+with `BD_BIN`:
+
+```bash
+docker run -p 3000:3000 \
+  -v /path/to/project:/data \
+  -v /usr/local/bin/bd:/usr/local/bin/bd \
+  -e BEADS_REPO=/data \
+  bead-me-up-scotty
+```
+
 ## Install globally
 
 Install once from a clone, then run `scotty` (or `bead-me-up-scotty`) from **any**

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,7 @@ const BUILD_NUMBER = process.env.BUILD_NUMBER || git("git rev-list --count HEAD"
 const BUILD_SHA = process.env.BUILD_SHA || git("git rev-parse --short=7 HEAD");
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   // Inlined into the bundle (client + server) so the build badge can read them.
   env: {
     NEXT_PUBLIC_BUILD_NUMBER: BUILD_NUMBER,

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,7 +15,12 @@ const BUILD_NUMBER = process.env.BUILD_NUMBER || git("git rev-list --count HEAD"
 const BUILD_SHA = process.env.BUILD_SHA || git("git rev-parse --short=7 HEAD");
 
 const nextConfig: NextConfig = {
-  output: "standalone",
+  // Standalone output is opt-in (set in the Dockerfile builder stage): the
+  // local launchers (npm start, scripts/serve.mjs, bin/bead-me-up-scotty.mjs)
+  // all run `next start`, which does not support standalone output, and
+  // package.json `files` ships `.next` — an unconditional standalone build
+  // would pack .next/standalone/node_modules into every global install.
+  ...(process.env.NEXT_STANDALONE ? { output: "standalone" as const } : {}),
   // Inlined into the bundle (client + server) so the build badge can read them.
   env: {
     NEXT_PUBLIC_BUILD_NUMBER: BUILD_NUMBER,


### PR DESCRIPTION
- Multi-stage build with builder
- standalone Next.js output
- non-root user.

This PR adds an opportunity to run this in container. So no npm install or npm dev required
Build:
```sh
docker build -t bead-me-up-scotty .
```

Run:
```sh
BEADS_REPO=/path/to/project
docker run -p 3000:3000 \
  --name beads_ui \
  -v $BEADS_REPO:/data \
  -e BEADS_REPO=/data \
  bead-me-up-scotty
```
Related issue:
https://github.com/brendan-appstart/bead-me-up-scotty/issues/2

## Summary by Sourcery

Add Docker-based container deployment support using a standalone Next.js build and document how to run the app in a container.

Enhancements:
- Configure Next.js to produce a standalone output suitable for minimal runtime images.

Deployment:
- Introduce a multi-stage Dockerfile that builds and runs the app as a non-root user in a lightweight Node.js Alpine container.
- Add a .dockerignore file to optimize Docker build context.

Documentation:
- Extend README with Docker build and run instructions, including demo mode usage and mounting real project data and the bd binary.