### PR TITLE
Render bead notes in detail drawer

### DIFF
--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -43,6 +43,8 @@ import { BEAD_STATUSES, BLOCKING_DEP_TYPES, type Bead, type DepType } from "@/li
 const selectClass =
   "h-9 cursor-pointer rounded-[9px] border border-border bg-[var(--surface-2)] px-[9px] text-[13px] text-[var(--text)] outline-none";
 const fieldLabel = "text-[11px] font-[550] uppercase tracking-[.03em] text-[var(--text-3)]";
+const detailContentClass =
+  "rounded-[10px] border border-border bg-[var(--surface-2)] p-[12px_13px] text-[13.5px] leading-[1.55] text-[var(--text-2)] [text-wrap:pretty]";
 
 export function BeadDetailDrawer({
   openId,
@@ -140,6 +142,7 @@ function DrawerBody({ bead, onClose }: { bead: Bead; onClose: () => void }) {
   const o = beadOrigin(bead, humanAllowlist);
   const ep = epicOf(bead, index);
   const deps = (bead.dependencies ?? []).filter((d) => d.type !== "parent-child");
+  const notes = bead.notes?.trim() ?? "";
   const comments = bead.comments ?? [];
   const activity = [
     { label: `Created by ${bead.created_by || "unknown"}`, time: fmtDate(bead.created_at) },
@@ -387,7 +390,7 @@ function DrawerBody({ bead, onClose }: { bead: Bead; onClose: () => void }) {
                   patch: { description: toggleTask(bead.description ?? "", idx) },
                 })
               }
-              className="rounded-[10px] border border-border bg-[var(--surface-2)] p-[12px_13px] text-[13.5px] leading-[1.55] text-[var(--text-2)] [text-wrap:pretty]"
+              className={detailContentClass}
             />
           ) : (
             <div className="rounded-[10px] border border-border bg-[var(--surface-2)] p-[12px_13px] text-[13.5px] leading-[1.55] text-[var(--text-3)]">
@@ -495,6 +498,17 @@ function DrawerBody({ bead, onClose }: { bead: Bead; onClose: () => void }) {
           </div>
         </Section>
 
+        {notes && (
+          <Section>
+            <Header icon="list" label="Notes" />
+            <DescriptionContent
+              text={notes}
+              projectId={projectId}
+              className={detailContentClass}
+            />
+          </Section>
+        )}
+
         {/* Comments */}
         <Section>
           <Header icon="comment" label="Comments" count={comments.length} />
@@ -582,12 +596,14 @@ function Section({ children }: { children: React.ReactNode }) {
   return <div className="mb-[18px]">{children}</div>;
 }
 
-function Header({ icon, label, count }: { icon: string; label: string; count: number }) {
+function Header({ icon, label, count }: { icon: string; label: string; count?: number }) {
   return (
     <div className="mb-[9px] flex items-center gap-2">
       <Icon name={icon} size={15} className="text-[var(--text-2)]" />
       <span className="text-[13px] font-semibold">{label}</span>
-      <span className="font-mono text-[11px] text-[var(--text-3)]">{count}</span>
+      {count !== undefined && (
+        <span className="font-mono text-[11px] text-[var(--text-3)]">{count}</span>
+      )}
     </div>
   );
 }

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -12,6 +12,7 @@ import type { Bead, Comment, Dependency } from "./schema";
 
 interface Extra {
   description?: string;
+  notes?: string;
   created_at?: string;
   updated_at?: string;
   closed_at?: string;
@@ -45,6 +46,7 @@ function D(
     assignee: assignee || "",
     created_by,
     description: extra.description ?? "",
+    notes: extra.notes ?? "",
     created_at: extra.created_at ?? "2026-06-09T10:00:00Z",
     updated_at: extra.updated_at ?? "2026-06-14T15:00:00Z",
     closed_at: status === "closed" ? extra.closed_at ?? "2026-06-15T11:00:00Z" : null,

--- a/lib/demo-store.ts
+++ b/lib/demo-store.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import type { Bead, CreateInput, UpdateInput, DepType, Dependency } from "./schema";
+import { beadSchema, type Bead, type CreateInput, type UpdateInput, type DepType, type Dependency } from "./schema";
 import type { BeadsStore, DoctorInfo } from "./store";
 import { demoBeads } from "./demo-data";
 
@@ -30,7 +30,7 @@ export const demoStore: BeadsStore = {
     const id = "bd-" + Math.random().toString(16).slice(2, 6);
     const dependencies: Dependency[] = [];
     if (input.parent) dependencies.push({ issue_id: id, depends_on_id: input.parent, type: "parent-child" });
-    const bead: Bead = {
+    const bead = beadSchema.parse({
       id,
       title: input.title.trim(),
       issue_type: input.issue_type,
@@ -46,7 +46,7 @@ export const demoStore: BeadsStore = {
       dependencies,
       comments: [],
       parent: input.parent || null,
-    };
+    });
     beads = [...beads, bead];
     return bead;
   },

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -87,6 +87,7 @@ export const beadSchema = z
     id: z.string(),
     title: z.string(),
     description: z.string().optional().default(""),
+    notes: z.string().optional().default(""),
     status: statusSchema,
     priority: z.coerce.number().int().min(0).max(4).default(2),
     issue_type: typeSchema,


### PR DESCRIPTION
## Summary
- preserve `notes` from bd JSON in the Bead schema
- render non-empty notes in the bead detail drawer between Dependencies and Comments
- initialise notes in demo data/store for type compatibility

## Validation
- Checked upstream first: no open PRs and no issues/PRs matching `notes OR note`
- `npm run lint`
- `npm run build` (passes; existing Turbopack NFT warning remains)

## Summary by Sourcery

Render bead notes in the detail drawer and wire notes through the bead schema and demo data.

New Features:
- Display bead notes in the detail drawer when present.

Enhancements:
- Extend the bead schema and demo/demo-store data to include a notes field for beads.