### PR TITLE
Render comments as markdown

### DIFF
--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -517,9 +517,11 @@ function DrawerBody({ bead, onClose }: { bead: Bead; onClose: () => void }) {
                         {relTime(c.created_at)}
                       </span>
                     </div>
-                    <div className="text-[13px] leading-[1.5] text-[var(--text-2)] [text-wrap:pretty]">
-                      {c.text}
-                    </div>
+                    <DescriptionContent
+                      text={c.text}
+                      projectId={projectId}
+                      className="text-[13px] leading-[1.5] text-[var(--text-2)] [text-wrap:pretty]"
+                    />
                   </div>
                 </div>
               );

--- a/components/description-content.tsx
+++ b/components/description-content.tsx
@@ -15,6 +15,11 @@ import { api } from "@/lib/api-client";
  *    caller can rewrite the source markdown (see lib/beads-view toggleTask).
  */
 const IMG_PATTERN = "!\\[([^\\]]*)\\]\\((attachment:\\/\\/[^)\\s]+|https?:\\/\\/[^)\\s]+)\\)";
+const SAFE_URL_PATTERN = /^(https?:|mailto:|attachment:\/\/)/i;
+
+function safeUrlTransform(url: string): string {
+  return SAFE_URL_PATTERN.test(url) ? url : "";
+}
 
 export function DescriptionContent({
   text,
@@ -70,9 +75,9 @@ export function DescriptionContent({
       <div className="bd-md">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
-          // Local single-user tool with trusted content; pass URLs (incl.
-          // attachment://) through untouched so the img override can resolve them.
-          urlTransform={(url) => url}
+          // Preserve attachment:// refs for local images, but reject executable
+          // or local-file schemes when comments/descriptions render user text.
+          urlTransform={safeUrlTransform}
           components={components}
         >
           {text}


### PR DESCRIPTION
## Summary
- render bead comments with the existing Markdown renderer
- preserve support for lists, links, code blocks, and multi-paragraph comments
- keep the branch independent from the notes rendering PR

## Validation
- `npm run lint`
- LSP diagnostics for `components/bead-detail-drawer.tsx`
- `npm run build` (passes; existing Turbopack NFT warning remains)

## Summary by Sourcery

Render bead comments using the shared markdown description component to support rich formatting.

New Features:
- Enable markdown rendering for bead comments, including lists, links, code blocks, and multi-paragraph content.

Enhancements:
- Reuse the existing DescriptionContent component for bead comment display to keep rendering behavior consistent across the app.