### PR TITLE
Prefix page title with database name

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,12 +2,13 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
+import { APP_TITLE } from "@/lib/app-title";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Bead Me Up, Scotty",
+  title: APP_TITLE,
   description: "A local web UI for the beads (bd) issue tracker",
 };
 

--- a/app/p/[projectId]/page.tsx
+++ b/app/p/[projectId]/page.tsx
@@ -1,10 +1,20 @@
+import type { Metadata } from "next";
 import { AppShell } from "@/components/app-shell";
+import { projectTitle } from "@/lib/app-title";
+import { getProject } from "@/lib/config";
 
-export default async function ProjectPage({
-  params,
-}: {
+type Props = {
   params: Promise<{ projectId: string }>;
-}) {
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { projectId } = await params;
+  const project = getProject(projectId);
+
+  return project ? { title: projectTitle(project.name) } : {};
+}
+
+export default async function ProjectPage({ params }: Props) {
   const { projectId } = await params;
   return <AppShell projectId={projectId} />;
 }

--- a/lib/app-title.ts
+++ b/lib/app-title.ts
@@ -1,0 +1,6 @@
+export const APP_TITLE = "Bead Me Up, Scotty";
+
+export function projectTitle(projectName: string): string {
+  const prefix = projectName.trim();
+  return prefix ? `${prefix} | ${APP_TITLE}` : APP_TITLE;
+}


### PR DESCRIPTION
## Summary
- add a shared app title helper
- set project page metadata to `<database name> | Bead Me Up, Scotty`
- keep the root/default title unchanged via the shared helper

## Testing
- npm run lint -- app/layout.tsx app/p/[projectId]/page.tsx lib/app-title.ts

## Summary by Sourcery

Prefix project page metadata titles with the selected database name while centralizing the base app title.

New Features:
- Derive per-project page metadata titles based on the project name combined with the shared app title.

Enhancements:
- Introduce a shared app title helper module used by both the root layout and project pages to keep title configuration consistent.