### PR TITLE
Avoid nested buttons in list rows

### DIFF
--- a/components/list-view.tsx
+++ b/components/list-view.tsx
@@ -202,19 +202,29 @@ function Row({
   });
   const o = beadOrigin(bead, humanAllowlist);
   const labels = (bead.labels ?? []).filter((l) => l !== "archived").slice(0, 2);
+  const openFromKeyboard = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onOpen();
+    }
+  };
   return (
-    <button
+    <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
+      role="button"
+      tabIndex={0}
       onClick={onOpen}
+      onKeyDown={openFromKeyboard}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
         opacity: isDragging ? 0.4 : 1,
         zIndex: isDragging ? 10 : undefined,
       }}
-      className="flex w-full touch-none items-center gap-3 rounded-[10px] border border-border bg-[var(--surface)] px-[13px] py-[9px] text-left transition-[border-color,box-shadow] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)]"
+      className="flex w-full cursor-pointer touch-none items-center gap-3 rounded-[10px] border border-border bg-[var(--surface)] px-[13px] py-[9px] text-left transition-[border-color,box-shadow] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
     >
       <span
         className="h-[9px] w-[9px] flex-shrink-0 rounded-full"
@@ -265,6 +275,6 @@ function Row({
       >
         {relTime(bead.updated_at)}
       </span>
-    </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- change list rows from button wrappers to div wrappers
- preserve row click behavior and pointer cursor
- prevent invalid nested `<button>` markup from CopyableId inside the row

## Testing
- npm run lint -- components/list-view.tsx app/layout.tsx app/p/[projectId]/page.tsx lib/app-title.ts

## Summary by Sourcery

Enhancements:
- Update list row container to use a div with cursor-pointer instead of a button to maintain UX while improving markup semantics.