### PR TITLE
fix(drawer): render bead close reasons

### DIFF
--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -151,6 +151,7 @@ function DrawerBody({ bead, onClose }: { bead: Bead; onClose: () => void }) {
   const notes = bead.notes?.trim() ?? "";
   const design = bead.design?.trim() ?? "";
   const acceptance = bead.acceptance_criteria?.trim() ?? "";
+  const closeReason = bead.close_reason?.trim() ?? "";
   const comments = bead.comments ?? [];
   const activity = [
     { label: `Created by ${bead.created_by || "unknown"}`, time: fmtDate(bead.created_at) },
@@ -595,6 +596,17 @@ function DrawerBody({ bead, onClose }: { bead: Bead; onClose: () => void }) {
             <Header icon="list" label="Notes" />
             <DescriptionContent
               text={notes}
+              projectId={projectId}
+              className={detailContentClass}
+            />
+          </Section>
+        )}
+
+        {closeReason && (
+          <Section>
+            <Header icon="check" label="Close reason" />
+            <DescriptionContent
+              text={closeReason}
               projectId={projectId}
               className={detailContentClass}
             />

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -55,7 +55,7 @@ function D(
     created_at: extra.created_at ?? "2026-06-09T10:00:00Z",
     updated_at: extra.updated_at ?? "2026-06-14T15:00:00Z",
     closed_at: status === "closed" ? extra.closed_at ?? "2026-06-15T11:00:00Z" : null,
-    close_reason: status === "closed" ? extra.close_reason ?? "" : "",
+    close_reason: status === "closed" ? extra.close_reason ?? "" : null,
     labels: extra.labels ?? [],
     dependencies,
     comments: extra.comments ?? [],

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -18,6 +18,7 @@ interface Extra {
   created_at?: string;
   updated_at?: string;
   closed_at?: string;
+  close_reason?: string;
   labels?: string[];
   comments?: Comment[];
   blocks?: string[];
@@ -54,6 +55,7 @@ function D(
     created_at: extra.created_at ?? "2026-06-09T10:00:00Z",
     updated_at: extra.updated_at ?? "2026-06-14T15:00:00Z",
     closed_at: status === "closed" ? extra.closed_at ?? "2026-06-15T11:00:00Z" : null,
+    close_reason: status === "closed" ? extra.close_reason ?? "" : "",
     labels: extra.labels ?? [],
     dependencies,
     comments: extra.comments ?? [],
@@ -108,7 +110,7 @@ export function demoBeads(): Bead[] {
     D("bd-44b1", "Decision: Backlog = deferred status", "decision", "closed", 1, "stevey", "stevey", null, { description: "Map the Backlog column to beads' built-in deferred status rather than inventing new schema.", comments: [cm("dana", "Agreed — zero new persisted state, stays correct with bd.", "2026-06-08T16:00:00Z")] }),
     D("bd-8d3e", "Bug: ready queue shows deferred beads", "bug", "open", 0, "claude-agent", "stevey", null, { description: "bd ready should exclude deferred; some deferred beads leak into Ready in the UI cache.", related: ["bd-3c71.1"], comments: [cm("claude-agent", "Repro: defer a bead, it stays in Ready until refetch.", "2026-06-16T08:00:00Z")] }),
     D("bd-2f9c", "Bug: drag-drop flickers on rollback", "bug", "blocked", 1, "cursor-agent", "cursor-agent", null, { description: "Optimistic move then adapter error causes a visible flicker on rollback.", related: ["bd-b18d.1"] }),
-    D("bd-5a77", "Switch integration to a REST API", "task", "closed", 3, "amp-bot", "amp-bot", null, { description: "Superseded — beads has no HTTP API; we shell out to the CLI.", labels: ["archived"], closed_at: "2026-06-07T10:00:00Z" }),
+    D("bd-5a77", "Switch integration to a REST API", "task", "closed", 3, "amp-bot", "amp-bot", null, { description: "Superseded — beads has no HTTP API; we shell out to the CLI.", labels: ["archived"], closed_at: "2026-06-07T10:00:00Z", close_reason: "Superseded by the CLI adapter approach." }),
 
     // ── Showcase beads for the newer features (Needs-You, checklists, Insights, Achievements) ──
     // Needs-You inbox: agent-escalated decisions (the `human` label, still open).

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -118,7 +118,7 @@ export const beadSchema = z
     updated_at: z.string().optional(),
     started_at: z.string().optional().nullable(),
     closed_at: z.string().optional().nullable(),
-    close_reason: z.string().optional().default(""),
+    close_reason: z.string().optional().nullable(),
     labels: z.array(z.string()).optional().default([]),
     dependencies: z.array(dependencySchema).optional().default([]),
     comments: z.array(commentSchema).optional().default([]),

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -118,6 +118,7 @@ export const beadSchema = z
     updated_at: z.string().optional(),
     started_at: z.string().optional().nullable(),
     closed_at: z.string().optional().nullable(),
+    close_reason: z.string().optional().default(""),
     labels: z.array(z.string()).optional().default([]),
     dependencies: z.array(dependencySchema).optional().default([]),
     comments: z.array(commentSchema).optional().default([]),


### PR DESCRIPTION
## Summary

Preserve closure context recorded by `bd close --reason` and surface it in the bead detail drawer. Previously, `close_reason` was omitted from the Zod schema, so it was stripped before reaching the UI.

This follows the same established approach as #13 / commit `2be335d`, which fixed Zod stripping `design` and `acceptance_criteria`, and #7, which added rendering for the previously omitted `notes` field. There was no existing issue or PR specifically covering `close_reason`.

## Changes

- Add `close_reason` to `beadSchema`
- Render non-empty close reasons as Markdown in the detail drawer
- Seed demo data with a close reason for local verification

## Testing

- `npm run lint`
- `npm run build`
- Verified `beadSchema` preserves Markdown-formatted `close_reason` values
- Verified a real project API response retains its stored close reason
- Verified the demo drawer renders the **Close reason** section and content

## Related work

- #13 — Render the design and acceptance criteria fields
- #7 — Render bead notes in the detail drawer

## Notes

This is display-only. Existing UI status changes continue to close beads without prompting for a reason.
