### PR TITLE
chore: add EditorConfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Define the repository's existing whitespace conventions so editors and automatic formatters use consistent settings instead of falling back to incompatible defaults. This was exposed while preparing #20, when an unconfigured formatter rewrote touched TypeScript files using tabs.

## Changes

- Mark the repository root with `root = true`
- Standardize UTF-8, LF line endings, final newlines, and trailing-whitespace cleanup
- Define two-space indentation to match the existing TypeScript, TSX, CSS, JSON, YAML, and shell sources
- Preserve Markdown trailing whitespace because two terminal spaces encode a hard line break

## Testing

- Verified the repository contains no existing `.editorconfig`
- Sampled indentation across tracked source types and confirmed space indentation with a two-space base
- `git diff --check`

## Related work

- #20 — Render bead close reasons in the detail drawer

## Notes

This PR adds configuration only; it does not reformat existing files.

## Summary by Sourcery

Add a repository-wide EditorConfig to codify existing whitespace and indentation conventions for consistent editor and formatter behavior.

Build:
- Introduce .editorconfig at the repo root to standardize charset, line endings, final newlines, trailing whitespace handling, and two-space indentation across source files.

Chores:
- Ensure Markdown files retain trailing spaces used for hard line breaks without altering existing file contents.