### PR TITLE
fix(theme): tolerate Node >=22 SSR localStorage stub without --localstorage-file

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -20,9 +20,15 @@ function storageKey(projectId: string | null): string {
  * purpose: a `typeof window === "undefined"` guard gets constant-folded to `true`
  * in the server bundle, which dead-code-eliminates the project-keyed read and
  * leaves the minifier emitting a temp before its declaration (TDZ during SSR).
+ *
+ * Node >= 22 exposes a `globalThis.localStorage` stub during SSR that lacks the
+ * Storage methods unless the process was started with `--localstorage-file`
+ * (calling `getItem` on it throws "is not a function"), so the object is only
+ * usable if it actually implements Storage.
  */
 function getStore(): Storage | undefined {
-  return (globalThis as { localStorage?: Storage }).localStorage;
+  const store = (globalThis as { localStorage?: Storage }).localStorage;
+  return typeof store?.getItem === "function" ? store : undefined;
 }
 
 function projectIdFromPath(pathname: string | null): string | null {


### PR DESCRIPTION
Node >= 22 exposes a `globalThis.localStorage` during SSR whose Storage methods are missing unless the process was started with `--localstorage-file` — the property access succeeds and returns an object, but calling `getItem` on it throws `TypeError: globalThis.localStorage.getItem is not a function`, crashing the first server render of any page that reads the theme.

Repro: `npm run dev` on Node 22+ (verified on v25.8), open any page — the server log shows the TypeError.

Fix: validate in `getStore()` that the object actually implements Storage (`typeof store?.getItem === "function"`), so every call site — the read path and both `setItem` paths — degrades to the default theme instead of throwing. Keeps the existing `globalThis` access pattern (the comment above `getStore` explains why a `typeof window` guard is a no-go here).

## Summary by Sourcery

Bug Fixes:
- Guard theme storage access by verifying that globalThis.localStorage implements the Storage interface before using it during SSR.