### PR TITLE
feat: read-only viewer mode (SCOTTY_READ_ONLY=1)

### DIFF
--- a/app/api/p/[projectId]/beads/route.ts
+++ b/app/api/p/[projectId]/beads/route.ts
@@ -1,5 +1,5 @@
 import { getStore } from "@/lib/store";
-import { getConfig } from "@/lib/config";
+import { getConfig, isReadOnly } from "@/lib/config";
 import { createInputSchema } from "@/lib/schema";
 import { ok, fail } from "@/lib/api";
 
@@ -21,6 +21,7 @@ export async function GET(_req: Request, { params }: Ctx) {
         humanAllowlist: cfg.humanAllowlist,
         pollIntervalMs: cfg.pollIntervalMs,
         gamification: cfg.gamification,
+        readOnly: isReadOnly(),
       },
     });
   } catch (e) {

--- a/components/app-context.tsx
+++ b/components/app-context.tsx
@@ -22,6 +22,8 @@ interface AppContextValue {
   index: Map<string, Bead>;
   meta?: Meta;
   humanAllowlist: string[];
+  /** Viewer mode (SCOTTY_READ_ONLY): hide write affordances; the server refuses writes anyway. */
+  readOnly: boolean;
   loading: boolean;
   error?: string;
   /** Open a bead, STARTING A FRESH trail (clears any back history). */

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -70,12 +70,17 @@ export function AppShell({ projectId }: { projectId: string }) {
       return next;
     });
   }, [index]);
+  // Viewer mode: every create entry point (board/list buttons, drawer subtask,
+  // palette, the `n` key) funnels through openCreate, so one guard covers all.
+  const readOnly = data?.meta?.readOnly ?? false;
   // Options object rather than positional args so future presets (assignee,
   // priority) can be added without churning every call site again.
   const openCreate = React.useCallback(
-    (opts: { parent?: string; type?: BeadType } = {}) =>
-      setCreate({ open: true, parent: opts.parent ?? "", type: opts.type }),
-    [],
+    (opts: { parent?: string; type?: BeadType } = {}) => {
+      if (readOnly) return;
+      setCreate({ open: true, parent: opts.parent ?? "", type: opts.type });
+    },
+    [readOnly],
   );
 
   // Jump to the Epics screen and focus an epic (bead 55b). The nonce makes each
@@ -135,6 +140,7 @@ export function AppShell({ projectId }: { projectId: string }) {
         index,
         meta: data?.meta,
         humanAllowlist: data?.meta?.humanAllowlist ?? [],
+        readOnly,
         loading: isLoading,
         error: errorMessage,
         openDetail,

--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -133,7 +133,7 @@ function DrawerBody({
   onBack?: () => void;
   onClose: () => void;
 }) {
-  const { index, beads, humanAllowlist, meta, projectId, pushDetail, openCreate } =
+  const { index, beads, humanAllowlist, meta, projectId, pushDetail, openCreate, readOnly } =
     useApp();
   const actor = meta?.humanActor ?? "you";
   const isDemo = meta?.kind === "demo";
@@ -264,27 +264,33 @@ function DrawerBody({
         <CopyableId id={bead.id} className="font-mono text-[13px] text-[var(--text-2)]" />
         <StatusChip status={bead.status} />
         <span className="flex-1" />
-        <IconBtn
-          title={editing ? "Stop editing" : "Edit title & description"}
-          onClick={editing ? cancelEdit : startEdit}
-        >
-          <Icon name="pencil" size={15} />
-        </IconBtn>
-        <IconBtn title="Archive (close + label)" onClick={() => archive.mutate(bead.id)}>
-          <Icon name="archive" size={15} />
-        </IconBtn>
-        <IconBtn
-          title="Delete"
-          danger
-          onClick={() => {
-            if (confirm(`Delete ${bead.id}? This calls bd delete.`)) {
-              del.mutate(bead.id);
-              onClose();
-            }
-          }}
-        >
-          <Icon name="trash" size={15} />
-        </IconBtn>
+        {!readOnly && (
+          <IconBtn
+            title={editing ? "Stop editing" : "Edit title & description"}
+            onClick={editing ? cancelEdit : startEdit}
+          >
+            <Icon name="pencil" size={15} />
+          </IconBtn>
+        )}
+        {!readOnly && (
+          <IconBtn title="Archive (close + label)" onClick={() => archive.mutate(bead.id)}>
+            <Icon name="archive" size={15} />
+          </IconBtn>
+        )}
+        {!readOnly && (
+          <IconBtn
+            title="Delete"
+            danger
+            onClick={() => {
+              if (confirm(`Delete ${bead.id}? This calls bd delete.`)) {
+                del.mutate(bead.id);
+                onClose();
+              }
+            }}
+          >
+            <Icon name="trash" size={15} />
+          </IconBtn>
+        )}
         <IconBtn title="Close" onClick={onClose}>
           <Icon name="x" size={15} />
         </IconBtn>
@@ -593,7 +599,7 @@ function DrawerBody({
               No description.
             </div>
           )}
-          {!editing && <AiAssistPanel bead={bead} />}
+          {!editing && !readOnly && <AiAssistPanel bead={bead} />}
         </Section>
 
         {/* Dependencies */}
@@ -821,13 +827,15 @@ function DrawerBody({
             {kids.length === 0 && (
               <div className="px-[2px] py-1 text-[12px] text-[var(--text-3)]">No subtasks yet.</div>
             )}
-            <button
-              onClick={() => openCreate({ parent: bead.id })}
-              className="flex items-center gap-[7px] rounded-[9px] border border-dashed border-[var(--border-strong)] p-[8px_11px] text-[12.5px] font-medium text-[var(--text-2)] hover:border-[var(--brand)] hover:text-[var(--brand)]"
-            >
-              <Icon name="plus" size={14} />
-              <span>Add subtask</span>
-            </button>
+            {!readOnly && (
+              <button
+                onClick={() => openCreate({ parent: bead.id })}
+                className="flex items-center gap-[7px] rounded-[9px] border border-dashed border-[var(--border-strong)] p-[8px_11px] text-[12.5px] font-medium text-[var(--text-2)] hover:border-[var(--brand)] hover:text-[var(--brand)]"
+              >
+                <Icon name="plus" size={14} />
+                <span>Add subtask</span>
+              </button>
+            )}
           </div>
         </Section>
 

--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -22,7 +22,7 @@ import { Column } from "./column";
 import type { Bead } from "@/lib/schema";
 
 export function Board() {
-  const { beads, index, humanAllowlist, openCreate, loading, projectId } = useApp();
+  const { beads, index, humanAllowlist, openCreate, loading, projectId, readOnly } = useApp();
   const setStatus = useSetStatus();
   const { data: orderData } = useOrder(projectId);
   const setOrder = useSetOrder(projectId);
@@ -93,6 +93,7 @@ export function Board() {
   }, [columns]);
 
   function onDragEnd(e: DragEndEvent) {
+    if (readOnly) return;
     const activeId = String(e.active.id);
     const overRaw = e.over?.id ? String(e.over.id) : null;
     if (!overRaw) return;
@@ -140,14 +141,16 @@ export function Board() {
           onShowArchived={setShowArchived}
         />
 
-        <button
-          onClick={() => openCreate()}
-          className="flex h-9 flex-shrink-0 items-center gap-[6px] rounded-[9px] px-[14px] text-[13px] font-[550] text-white"
-          style={{ background: "var(--brand)", boxShadow: "0 2px 8px -2px var(--brand)" }}
-        >
-          <Icon name="plus" size={15} />
-          <span>New</span>
-        </button>
+        {!readOnly && (
+          <button
+            onClick={() => openCreate()}
+            className="flex h-9 flex-shrink-0 items-center gap-[6px] rounded-[9px] px-[14px] text-[13px] font-[550] text-white"
+            style={{ background: "var(--brand)", boxShadow: "0 2px 8px -2px var(--brand)" }}
+          >
+            <Icon name="plus" size={15} />
+            <span>New</span>
+          </button>
+        )}
       </header>
 
       <div className="bd-scroll min-h-0 flex-1 overflow-x-auto overflow-y-hidden p-[18px_22px]">

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -108,7 +108,7 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
 }
 
 export function GraphView() {
-  const { beads, openDetail } = useApp();
+  const { beads, openDetail, readOnly } = useApp();
   const addDep = useAddDep();
   // Recenter/fit the graph on the current nodes (bead mpe).
   const rf = React.useRef<ReactFlowInstance | null>(null);
@@ -121,11 +121,12 @@ export function GraphView() {
 
   const onConnect = React.useCallback(
     (c: Connection) => {
+      if (readOnly) return;
       if (c.source && c.target && c.source !== c.target) {
         addDep.mutate({ id: c.source, dependsOnId: c.target, type: "blocks" });
       }
     },
-    [addDep],
+    [addDep, readOnly],
   );
 
   return (
@@ -152,6 +153,7 @@ export function GraphView() {
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
+          nodesConnectable={!readOnly}
           onConnect={onConnect}
           onInit={(inst) => {
             rf.current = inst;

--- a/components/list-view.tsx
+++ b/components/list-view.tsx
@@ -53,7 +53,7 @@ function rankOf(order: string[] | undefined, id: string): number {
 }
 
 export function ListView() {
-  const { beads, index, humanAllowlist, openDetail, openCreate, openEpic, loading, projectId } =
+  const { beads, index, humanAllowlist, openDetail, openCreate, openEpic, loading, projectId, readOnly } =
     useApp();
   const setStatus = useSetStatus();
   const { data: orderData } = useOrder(projectId);
@@ -121,6 +121,7 @@ export function ListView() {
   }, [rows, colById]);
 
   function onDragEnd(e: DragEndEvent) {
+    if (readOnly) return;
     const activeId = String(e.active.id);
     const overId = e.over?.id ? String(e.over.id) : null;
     if (!overId || overId === activeId) return;
@@ -163,14 +164,16 @@ export function ListView() {
           onShowArchived={setShowArchived}
         />
 
-        <button
-          onClick={() => openCreate()}
-          className="flex h-9 flex-shrink-0 items-center gap-[6px] rounded-[9px] px-[14px] text-[13px] font-[550] text-white"
-          style={{ background: "var(--brand)", boxShadow: "0 2px 8px -2px var(--brand)" }}
-        >
-          <Icon name="plus" size={15} />
-          <span>New</span>
-        </button>
+        {!readOnly && (
+          <button
+            onClick={() => openCreate()}
+            className="flex h-9 flex-shrink-0 items-center gap-[6px] rounded-[9px] px-[14px] text-[13px] font-[550] text-white"
+            style={{ background: "var(--brand)", boxShadow: "0 2px 8px -2px var(--brand)" }}
+          >
+            <Icon name="plus" size={15} />
+            <span>New</span>
+          </button>
+        )}
       </header>
 
       <div className="bd-scroll min-h-0 flex-1 overflow-y-auto p-[12px_22px]">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -62,7 +62,7 @@ export function Sidebar({
   live?: boolean;
 }) {
   const { mode, toggle } = useTheme();
-  const { meta, beads, index } = useApp();
+  const { meta, beads, index, readOnly } = useApp();
   const actor = meta?.humanActor ?? "you";
   const epicCount = beads.filter((b) => b.issue_type === "epic").length;
   // "Needs You" = agent-flagged beads (bd human) + ready human-approval gates.
@@ -85,6 +85,16 @@ export function Sidebar({
       </div>
 
       <ProjectSwitcher projectId={projectId} kind={kind} live={live} />
+
+      {readOnly && (
+        <div
+          className="mx-2 mb-3 flex items-center gap-[7px] rounded-[9px] border border-border bg-[var(--surface-2)] px-[10px] py-[6px] text-[11.5px] font-semibold text-[var(--text-2)]"
+          title="SCOTTY_READ_ONLY is set: this board is a viewer; writes go through the bd CLI"
+        >
+          <Icon name="gate" size={13} className="flex-shrink-0" />
+          <span>Read-only viewer</span>
+        </div>
+      )}
 
       <nav className="flex flex-col gap-[2px]">
         {NAV.filter((n) => n.key !== "achievements" || meta?.gamification).map((n) => {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -7,6 +7,8 @@ export interface Meta {
   humanAllowlist: string[];
   pollIntervalMs: number;
   gamification?: boolean;
+  /** Viewer mode (SCOTTY_READ_ONLY): the server refuses writes; the UI hides them. */
+  readOnly?: boolean;
 }
 export interface BeadsResponse {
   beads: Bead[];

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -55,6 +55,17 @@ export class ConfigError extends Error {
   }
 }
 
+/**
+ * Viewer mode: SCOTTY_READ_ONLY=1 (or "true") makes the app a pure read-only
+ * pane over the beads store — every project-data mutation is refused
+ * server-side (see middleware.ts) and the write affordances are hidden in the
+ * UI. Useful when bd CLI owns all writes and the board must not diverge.
+ */
+export function isReadOnly(): boolean {
+  const v = process.env.SCOTTY_READ_ONLY;
+  return v === "1" || v === "true";
+}
+
 function configDir(): string {
   const base = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
   return path.join(base, "bead-me-up-scotty");

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Viewer mode (SCOTTY_READ_ONLY=1): refuse every project-data mutation at one
+ * choke point instead of guarding each route handler. Anything non-GET under
+ * /api/p/ writes bead data, attachments, ordering, or publishes — all of it is
+ * off-limits when the beads store is owned by an external writer (the bd CLI).
+ * App-level endpoints (/api/config, /api/projects, /api/update) stay available:
+ * they manage this app, not the beads data.
+ *
+ * The UI also hides its write affordances (via meta.readOnly), but this is the
+ * authoritative guard.
+ */
+export function middleware(req: NextRequest) {
+  const readOnly = process.env.SCOTTY_READ_ONLY === "1" || process.env.SCOTTY_READ_ONLY === "true";
+  if (readOnly && req.method !== "GET" && req.method !== "HEAD" && req.method !== "OPTIONS") {
+    return NextResponse.json(
+      { error: "read-only mode (SCOTTY_READ_ONLY): writes go through the bd CLI", code: "read_only" },
+      { status: 403 },
+    );
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/api/p/:path*",
+};


### PR DESCRIPTION
Adds an opt-in **viewer mode** for setups where an external writer owns the beads store — e.g. agents and humans writing through the `bd` CLI — and the board serves as a pure always-on visual pane that must not diverge from CLI-owned state.

Set `SCOTTY_READ_ONLY=1` (or `true`) and:

- **Server-side (authoritative):** a middleware refuses every non-GET request under `/api/p/` with `403 {code: "read_only"}` — one choke point instead of guarding 14 route handlers, and it covers future routes for free. App-level endpoints (`/api/config`, `/api/projects`, `/api/update`) stay available; they manage the app, not the beads data.
- **Client-side:** `meta.readOnly` rides the beads response and the UI hides its write affordances — New-bead buttons (board/list), drawer edit/archive/delete, AI-assist panel, add-subtask, board/list drag-to-reorder/re-status, graph connect (`nodesConnectable={false}`). A "Read-only viewer" badge in the sidebar names the mode so it never feels broken.

Default behavior is unchanged (flag unset → everything as before).

Tested against a live ~1000-bead bd project: GET returns `meta.readOnly: true`, PATCH/POST return the 403 envelope (message surfaces in the existing error toast if a write path is reached some other way).

## Summary by Sourcery

Introduce an opt-in read-only viewer mode controlled by SCOTTY_READ_ONLY that makes the board a non-mutating visual pane over the beads store.

New Features:
- Add SCOTTY_READ_ONLY environment flag that enables a read-only viewer mode where project data mutations are rejected server-side and write affordances are hidden in the UI.

Enhancements:
- Propagate a readOnly meta flag from the beads API through app context so board, list, drawer, graph, and sidebar can adapt their behavior and messaging accordingly.

Chores:
- Centralize read-only enforcement for project APIs via a Next.js middleware that blocks non-GET/HEAD/OPTIONS requests under /api/p/.