### PR TITLE
feat: Focus view — a 'what's happening now' landing tab, with optional lane chips

### DIFF
--- a/app/api/p/[projectId]/beads/route.ts
+++ b/app/api/p/[projectId]/beads/route.ts
@@ -1,5 +1,5 @@
 import { getStore } from "@/lib/store";
-import { getConfig } from "@/lib/config";
+import { getConfig, lanePrefix } from "@/lib/config";
 import { createInputSchema } from "@/lib/schema";
 import { ok, fail } from "@/lib/api";
 
@@ -21,6 +21,7 @@ export async function GET(_req: Request, { params }: Ctx) {
         humanAllowlist: cfg.humanAllowlist,
         pollIntervalMs: cfg.pollIntervalMs,
         gamification: cfg.gamification,
+        lanePrefix: lanePrefix(),
       },
     });
   } catch (e) {

--- a/components/app-context.tsx
+++ b/components/app-context.tsx
@@ -5,6 +5,7 @@ import type { Bead } from "@/lib/schema";
 import type { Meta } from "@/lib/api-client";
 
 export type View =
+  | "focus"
   | "board"
   | "list"
   | "epics"

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -10,6 +10,7 @@ import { makeIndex } from "@/lib/beads-view";
 import { AppProvider } from "@/components/app-context";
 import { Sidebar } from "@/components/sidebar";
 import { Board } from "@/components/board/board";
+import { FocusView } from "@/components/focus-view";
 import { ListView } from "@/components/list-view";
 import { EpicsView } from "@/components/epics-view";
 import { GraphView } from "@/components/graph-view";
@@ -170,6 +171,7 @@ export function AppShell({ projectId }: { projectId: string }) {
               {view === "board" && <Board />}
               {view === "list" && <ListView />}
               {view === "epics" && <EpicsView focusEpic={focusEpic} />}
+              {view === "focus" && <FocusView />}
               {view === "graph" && <GraphView />}
               {view === "insights" && <InsightsView />}
               {view === "activity" && <ActivityView />}

--- a/components/focus-view.tsx
+++ b/components/focus-view.tsx
@@ -1,0 +1,200 @@
+"use client";
+import * as React from "react";
+import { useApp } from "@/components/app-context";
+import { Icon, typeIconName } from "@/components/icons";
+import { PriorityChip } from "@/components/board/bead-card";
+import { isBlocked, blockingDeps, relTime, fmtDateTime, typeColor, catColor } from "@/lib/beads-view";
+import type { Bead } from "@/lib/schema";
+
+/**
+ * Focus — "what's happening now". Three fixed columns cut by status × priority:
+ *
+ *   In flight — in_progress (the threads someone has actually claimed)
+ *   Blocked   — blocked status, or open with an unresolved blocking dep
+ *   Next up   — open, unblocked, P0/P1 only
+ *
+ * Everything else (the deep ready pool, P2+ backlog, closed work) stays behind
+ * the Board/List views — that's the point: a landing screen that answers
+ * "what's in flight, what's stuck, what would I pick up next" without scrolling.
+ *
+ * Lane chips: when SCOTTY_LANE_PREFIX is set (e.g. "ctx:"), one chip per lane
+ * label found on the visible beads filters all three columns — a one-click
+ * "show me this lane's now". Unset → no chips.
+ */
+
+const ARCHIVED = "archived";
+
+function laneOf(b: Bead, prefix: string): string | null {
+  const l = (b.labels ?? []).find((x) => x.startsWith(prefix));
+  return l ? l.slice(prefix.length) : null;
+}
+
+export function FocusView() {
+  const { beads, index, meta } = useApp();
+  const prefix = meta?.lanePrefix ?? null;
+  const [lane, setLane] = React.useState<string | null>(null); // null = all, "" = unlabeled
+
+  const active = React.useMemo(
+    () => beads.filter((b) => !(b.labels ?? []).includes(ARCHIVED)),
+    [beads],
+  );
+
+  const lanes = React.useMemo(() => {
+    if (!prefix) return [];
+    const s = new Set<string>();
+    for (const b of active) {
+      if (b.status !== "in_progress" && b.status !== "blocked" && b.status !== "open") continue;
+      const l = laneOf(b, prefix);
+      if (l) s.add(l);
+    }
+    return [...s].sort();
+  }, [active, prefix]);
+
+  const inLane = React.useCallback(
+    (b: Bead) => {
+      if (!prefix || lane === null) return true;
+      const l = laneOf(b, prefix);
+      return lane === "" ? l === null : l === lane;
+    },
+    [prefix, lane],
+  );
+
+  const inFlight = React.useMemo(
+    () => active.filter((b) => b.status === "in_progress" && inLane(b)),
+    [active, inLane],
+  );
+  const blocked = React.useMemo(
+    () => active.filter((b) => isBlocked(b, index) && inLane(b)),
+    [active, index, inLane],
+  );
+  const nextUp = React.useMemo(
+    () =>
+      active.filter(
+        (b) => b.status === "open" && b.priority <= 1 && !isBlocked(b, index) && inLane(b),
+      ),
+    [active, index, inLane],
+  );
+
+  const columns: { title: string; hint: string; items: Bead[] }[] = [
+    { title: "In flight", hint: "in_progress", items: inFlight },
+    { title: "Blocked", hint: "waiting on a dependency", items: blocked },
+    { title: "Next up", hint: "ready · P0/P1", items: nextUp },
+  ];
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex flex-shrink-0 items-center gap-3 border-b border-border bg-[var(--surface)] p-[14px_22px]">
+        <div className="mr-1 flex flex-col gap-px">
+          <h1 className="m-0 text-base font-[650] tracking-[-.01em]">Focus</h1>
+          <span className="text-[11.5px] text-[var(--text-3)]">
+            what&rsquo;s happening now · {inFlight.length} in flight · {blocked.length} blocked ·{" "}
+            {nextUp.length} next up
+          </span>
+        </div>
+        <span className="flex-1" />
+        {prefix && lanes.length > 0 && (
+          <div className="flex flex-wrap items-center gap-[6px]">
+            <LaneChip label="All" selected={lane === null} onClick={() => setLane(null)} />
+            {lanes.map((l) => (
+              <LaneChip
+                key={l}
+                label={l}
+                selected={lane === l}
+                onClick={() => setLane(lane === l ? null : l)}
+              />
+            ))}
+            <LaneChip
+              label="unlabeled"
+              selected={lane === ""}
+              onClick={() => setLane(lane === "" ? null : "")}
+            />
+          </div>
+        )}
+      </header>
+
+      <div className="bd-scroll min-h-0 flex-1 overflow-x-auto overflow-y-hidden p-[18px_22px]">
+        <div className="flex h-full min-h-0 gap-4">
+          {columns.map((c) => (
+            <section key={c.title} className="flex h-full min-h-0 w-[320px] flex-shrink-0 flex-col">
+              <div className="mb-2 flex items-baseline gap-2 px-1">
+                <h2 className="m-0 text-[13px] font-[650] text-[var(--text)]">{c.title}</h2>
+                <span className="text-[11px] text-[var(--text-3)]">
+                  {c.items.length} · {c.hint}
+                </span>
+              </div>
+              <div className="bd-scroll min-h-0 flex-1 overflow-y-auto rounded-[12px] border border-border bg-[var(--surface-2)] p-2">
+                {c.items.length === 0 ? (
+                  <div className="p-4 text-center text-[12px] text-[var(--text-3)]">Nothing here.</div>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {c.items.map((b) => (
+                      <FocusCard key={b.id} bead={b} showBlockers={c.title === "Blocked"} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LaneChip({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="rounded-full border px-[10px] py-[3px] text-[11.5px] font-[550] transition-colors"
+      style={
+        selected
+          ? { borderColor: "var(--brand)", background: "var(--brand-weak)", color: "var(--brand)" }
+          : { borderColor: "var(--border)", background: "var(--surface)", color: "var(--text-2)" }
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
+function FocusCard({ bead, showBlockers }: { bead: Bead; showBlockers?: boolean }) {
+  const { index, openDetail } = useApp();
+  const blockers = showBlockers ? blockingDeps(bead, index) : [];
+  return (
+    <article
+      onClick={() => openDetail(bead.id)}
+      className="cursor-pointer rounded-[11px] border border-border bg-[var(--surface)] p-[10px_12px] shadow-[var(--shadow)] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-lg)]"
+    >
+      <div className="mb-[5px] flex items-center gap-[7px]">
+        <span className="h-2 w-2 flex-shrink-0 rounded-full" style={{ background: catColor(bead.status) }} />
+        <span className="font-mono text-[10.5px] text-[var(--text-3)]">{bead.id}</span>
+        <span className="flex-1" />
+        <PriorityChip p={bead.priority} />
+        <Icon
+          name={typeIconName(bead.issue_type)}
+          size={13}
+          style={{ color: typeColor(bead.issue_type) }}
+        />
+      </div>
+      <div className="text-[12.5px] font-[550] leading-[1.35] text-[var(--text)] [text-wrap:pretty]">
+        {bead.title}
+      </div>
+      <div className="mt-[6px] flex items-center gap-[8px] text-[10.5px] text-[var(--text-3)]">
+        <span title={fmtDateTime(bead.updated_at)}>{relTime(bead.updated_at)}</span>
+        {blockers.length > 0 && (
+          <span className="truncate font-mono" title={`blocked by ${blockers.join(", ")}`}>
+            ⛔ {blockers.join(", ")}
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -36,6 +36,7 @@ function openIssue(kind: "bug" | "feature") {
 }
 
 const NAV: { key: View; label: string; icon: string }[] = [
+  { key: "focus", label: "Focus", icon: "target" },
   { key: "board", label: "Board", icon: "board" },
   { key: "list", label: "List", icon: "list" },
   { key: "epics", label: "Epics", icon: "target" },

--- a/hooks/use-last-view.ts
+++ b/hooks/use-last-view.ts
@@ -3,6 +3,7 @@ import * as React from "react";
 import type { View } from "@/components/app-context";
 
 const VIEWS: View[] = [
+  "focus",
   "board",
   "list",
   "epics",
@@ -21,8 +22,8 @@ const EVT = "bmus:view";
 /**
  * Remembers the active view per project in localStorage (bead 433). Uses
  * useSyncExternalStore so it's SSR-safe: the server and the first client render
- * both return "board" (matching the server HTML), then it syncs to the stored
- * value — no setState-in-effect and no hydration mismatch. Falls back to "board"
+ * both return "focus" (matching the server HTML), then it syncs to the stored
+ * value — no setState-in-effect and no hydration mismatch. Falls back to "focus"
  * for unknown/removed view ids.
  */
 export function useLastView(projectId: string): [View, (v: View) => void] {
@@ -37,9 +38,9 @@ export function useLastView(projectId: string): [View, (v: View) => void] {
   }, []);
   const getSnapshot = React.useCallback((): View => {
     const v = localStorage.getItem(key);
-    return isView(v) ? v : "board";
+    return isView(v) ? v : "focus";
   }, [key]);
-  const view = React.useSyncExternalStore(subscribe, getSnapshot, () => "board" as View);
+  const view = React.useSyncExternalStore(subscribe, getSnapshot, () => "focus" as View);
   const setView = React.useCallback(
     (v: View) => {
       localStorage.setItem(key, v);

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -7,6 +7,8 @@ export interface Meta {
   humanAllowlist: string[];
   pollIntervalMs: number;
   gamification?: boolean;
+  /** Label prefix (SCOTTY_LANE_PREFIX) that partitions work into Focus-view lane chips. */
+  lanePrefix?: string | null;
 }
 export interface BeadsResponse {
   beads: Bead[];

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -55,6 +55,16 @@ export class ConfigError extends Error {
   }
 }
 
+/**
+ * Focus-view lane chips: SCOTTY_LANE_PREFIX names a label prefix (e.g. "ctx:")
+ * whose values partition work into lanes/teams/areas. When set, the Focus view
+ * offers one filter chip per lane label found on the visible beads. Unset →
+ * no chips (the feature is invisible).
+ */
+export function lanePrefix(): string | null {
+  return process.env.SCOTTY_LANE_PREFIX || null;
+}
+
 function configDir(): string {
   const base = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
   return path.join(base, "bead-me-up-scotty");


### PR DESCRIPTION
On a project with a deep backlog, no screen answers *"what's in flight, what's stuck, what would I pick up next"* without scrolling — the Board shows everything. **Focus** is a new view with a fixed status × priority cut:

| Column | Contents |
|---|---|
| **In flight** | `in_progress` |
| **Blocked** | `blocked` status, or open with an unresolved blocking dep (reuses `isBlocked`/`blockingDeps`; blockers listed on the card) |
| **Next up** | open, unblocked, **P0/P1 only** |

Everything else (the deep ready pool, P2+ backlog, closed work) stays behind Board/List — that's the point. Focus becomes the default landing view for a project; the existing last-used-view memory still wins once stored (`useLastView` fallback moves from "board" to "focus", both SSR snapshots updated together so there's no hydration mismatch).

**Lane chips (opt-in):** set `SCOTTY_LANE_PREFIX` (e.g. `ctx:`) to name a label prefix that partitions work into lanes/teams/areas. Focus then shows one chip per lane label found on the open/in-progress/blocked beads (+ **All** / **unlabeled**) and filters all three columns — a one-click "show me this lane's now". Unset → no chips, nothing changes.

Cards are a lightweight non-draggable variant reusing the existing `PriorityChip`, icon, status-dot and relTime helpers, click-through to the detail drawer.

Tested against a live ~1000-bead bd project: 17 in flight · 50 blocked · 69 next up, lane chips derived correctly from `ctx:*` labels.

## Summary by Sourcery

Add a new Focus landing view that surfaces in-flight, blocked, and next-up work and make it the default project view, with optional lane-based filtering driven by a configurable label prefix.

New Features:
- Introduce a Focus view with three fixed columns showing in-flight, blocked, and high-priority next-up items.
- Add optional lane chips that filter Focus columns based on a configurable label prefix provided via SCOTTY_LANE_PREFIX.
- Expose the configured lane label prefix from the backend API to the client meta state and render it in the UI when present.

Enhancements:
- Make Focus the default initial view for projects while preserving last-used view behavior via the use-last-view hook.
- Extend navigation and app shell routing to support selecting and rendering the new Focus view.