### PR TITLE
fix(epics): make hide-closed filter authoritative

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -82,6 +82,7 @@ export function AppShell({ projectId }: { projectId: string }) {
   // request distinct so clicking the same epic again re-triggers the scroll.
   const [focusEpic, setFocusEpic] = React.useState<{ id: string; nonce: number } | null>(null);
   const focusNonce = React.useRef(0);
+  const clearFocusEpic = React.useCallback(() => setFocusEpic(null), []);
   const openEpic = React.useCallback(
     (epicId: string) => {
       setOpenStack([]); // close the detail drawer
@@ -169,7 +170,9 @@ export function AppShell({ projectId }: { projectId: string }) {
             <>
               {view === "board" && <Board />}
               {view === "list" && <ListView />}
-              {view === "epics" && <EpicsView focusEpic={focusEpic} />}
+              {view === "epics" && (
+                <EpicsView focusEpic={focusEpic} onFocusHandledAction={clearFocusEpic} />
+              )}
               {view === "graph" && <GraphView />}
               {view === "insights" && <InsightsView />}
               {view === "activity" && <ActivityView />}

--- a/components/epics-view.tsx
+++ b/components/epics-view.tsx
@@ -43,10 +43,19 @@ function LabelChips({ labels, max }: { labels: string[]; max: number }) {
   );
 }
 
-export function EpicsView({ focusEpic }: { focusEpic?: { id: string; nonce: number } | null }) {
+export function EpicsView({
+  focusEpic,
+  onFocusHandledAction,
+}: {
+  focusEpic?: { id: string; nonce: number } | null;
+  onFocusHandledAction?: () => void;
+}) {
   const { beads, humanAllowlist, openCreate, openDetail } = useApp();
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
   const [hideClosed, setHideClosed] = React.useState(true);
+  const flashedElement = React.useRef<HTMLElement | null>(null);
+  const focusFrame = React.useRef<number | null>(null);
+  const flashTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   // Explicitly ordered: open before closed, then priority ascending, then id
   // for stability. Previously a bare .filter(), so the apparent priority order
   // was incidental to whatever `bd export` returned.
@@ -59,24 +68,50 @@ export function EpicsView({ focusEpic }: { focusEpic?: { id: string; nonce: numb
         a.id.localeCompare(b.id),
     );
   // "Filter out closed" (bead 8vm): hide closed epics (and closed children below).
-  // Progress % still counts all children, so it stays accurate. A focused epic —
-  // jumped to from a bead's detail drawer (bead 55b) — is always shown.
+  // Progress % still counts all children, so it stays accurate. A newly focused
+  // closed epic is included for the first render; the focus effect then turns
+  // this filter off so the control accurately reflects what is visible.
   const epics = allEpics.filter(
     (e) => !hideClosed || e.status !== "closed" || e.id === focusEpic?.id,
   );
 
-  // On a focus request, scroll the target epic into view and flash it. DOM-only
-  // side effects (no setState) keep this a clean effect; the nonce re-triggers it
-  // even when the same epic is requested twice.
+  // Consume each focus request after scrolling. Keeping a handled request in
+  // AppShell made its closed-epic exception permanent, so "Hide closed" could
+  // never hide that epic and returning to this view focused it again.
   React.useEffect(() => {
     if (!focusEpic) return;
     const el = document.querySelector<HTMLElement>(`[data-epic-id="${CSS.escape(focusEpic.id)}"]`);
     if (!el) return;
+
+    const focusedEpic = beads.find((bead) => bead.id === focusEpic.id);
+    if (focusFrame.current !== null) cancelAnimationFrame(focusFrame.current);
+    focusFrame.current = requestAnimationFrame(() => {
+      if (focusedEpic?.status === "closed") setHideClosed(false);
+      setExpanded((state) => ({ ...state, [focusEpic.id]: true }));
+      onFocusHandledAction?.();
+      focusFrame.current = null;
+    });
+
+    if (flashTimeout.current) clearTimeout(flashTimeout.current);
+    flashedElement.current?.classList.remove("epic-flash");
+    flashedElement.current = el;
     el.scrollIntoView({ behavior: "smooth", block: "start" });
     el.classList.add("epic-flash");
-    const t = setTimeout(() => el.classList.remove("epic-flash"), 1600);
-    return () => clearTimeout(t);
-  }, [focusEpic]);
+    flashTimeout.current = setTimeout(() => {
+      el.classList.remove("epic-flash");
+      flashedElement.current = null;
+      flashTimeout.current = null;
+    }, 1600);
+  }, [beads, focusEpic, onFocusHandledAction]);
+
+  React.useEffect(
+    () => () => {
+      if (focusFrame.current !== null) cancelAnimationFrame(focusFrame.current);
+      if (flashTimeout.current) clearTimeout(flashTimeout.current);
+      flashedElement.current?.classList.remove("epic-flash");
+    },
+    [],
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col">


### PR DESCRIPTION
# Fix the Epics “Hide closed” filter after focused navigation

## Summary

A closed epic opened via the parent-epic navigation remained permanently exempt from “Hide closed”. This made the filter appear enabled while the focused closed epic stayed visible, and revisiting the Epics view repeated the stale focus.

## Changes

- Consume an epic focus request after scrolling and auto-expanding its target.
- Turn off “Hide closed” when navigation intentionally focuses a closed epic, keeping the control consistent with the visible list.
- Preserve and clean up the focus flash timer across repeated navigation and unmounts.

## Testing

- `npm run lint`
- `npm run build`
- Manually verified the filter in the demo Epics view: disabling it shows the closed epic, and re-enabling it hides the closed epic again.

## Notes

The production build passes with the existing Turbopack NFT tracing warning from `next.config.ts`.

## Summary by Sourcery

Fix the Epics view focus behavior so closed epics interacted with via navigation no longer bypass the “Hide closed” filter or remain permanently focused.

Bug Fixes:
- Ensure focused closed epics are no longer permanently exempt from the “Hide closed” filter in the Epics view.
- Prevent stale epic focus from persisting when returning to the Epics view after navigation.

Enhancements:
- Consume epic focus requests in the Epics view and clear them in the app shell once handled to keep navigation state consistent.
- Stabilize and clean up the focus flash scrolling effect using refs so repeated navigation and unmounts do not leave stray timers or animation frames.