### PR TITLE
fix(palette): keep command list inside viewport

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -53,6 +53,11 @@
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) * 1.4);
+
+  /* The command palette's dialog and its inner Command element each need a
+     max-height, and the two must agree or the list scrolls against a boundary
+     the outer box doesn't share. One definition keeps them from drifting. */
+  --palette-max-height: calc(100dvh - 4rem);
 }
 
 :root {

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -56,7 +56,7 @@ export function CommandPalette({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="flex max-h-[calc(100dvh-4rem)] flex-col gap-0 overflow-hidden rounded-2xl border border-border bg-[var(--surface)] p-0 shadow-[var(--shadow-lg)] sm:max-w-[640px]"
+        className="flex max-h-(--palette-max-height) flex-col gap-0 overflow-hidden rounded-2xl border border-border bg-[var(--surface)] p-0 shadow-[var(--shadow-lg)] sm:max-w-[640px]"
         style={{ width: 640, maxWidth: "94vw" }}
       >
         <DialogTitle className="sr-only">Command palette</DialogTitle>
@@ -103,7 +103,7 @@ function PaletteBody({ onView, close }: { onView: (v: View) => void; close: () =
   return (
     <Command
       label="Command palette"
-      className="flex min-h-0 w-full max-h-[min(680px,calc(100dvh-4rem))] flex-col"
+      className="flex min-h-0 w-full max-h-[min(680px,var(--palette-max-height))] flex-col"
       onKeyDown={(e) => {
         // Backspace on an empty query steps back out of a sub-page.
         if (e.key === "Backspace" && search === "" && page !== "root") {

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -56,7 +56,7 @@ export function CommandPalette({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="top-[12%] translate-y-0 gap-0 overflow-hidden rounded-2xl border border-border bg-[var(--surface)] p-0 shadow-[var(--shadow-lg)] sm:max-w-[640px]"
+        className="flex max-h-[calc(100dvh-4rem)] flex-col gap-0 overflow-hidden rounded-2xl border border-border bg-[var(--surface)] p-0 shadow-[var(--shadow-lg)] sm:max-w-[640px]"
         style={{ width: 640, maxWidth: "94vw" }}
       >
         <DialogTitle className="sr-only">Command palette</DialogTitle>
@@ -103,7 +103,7 @@ function PaletteBody({ onView, close }: { onView: (v: View) => void; close: () =
   return (
     <Command
       label="Command palette"
-      className="flex max-h-[60vh] flex-col"
+      className="flex min-h-0 w-full max-h-[min(680px,calc(100dvh-4rem))] flex-col"
       onKeyDown={(e) => {
         // Backspace on an empty query steps back out of a sub-page.
         if (e.key === "Backspace" && search === "" && page !== "root") {
@@ -145,7 +145,7 @@ function PaletteBody({ onView, close }: { onView: (v: View) => void; close: () =
         />
       </div>
 
-      <Command.List className="overflow-y-auto p-2">
+      <Command.List className="min-h-0 flex-1 overflow-y-auto p-2 pb-4">
         <Command.Empty className="px-3 py-6 text-center text-[13px] text-[var(--text-3)]">
           No results.
         </Command.Empty>


### PR DESCRIPTION
## Summary

- constrain the command palette relative to the dynamic viewport while preserving space around its edges
- make the command list the flexing scroll region instead of allowing it to reach the dialog's clipping boundary
- add bottom padding so the final result remains fully visible above the rounded edge

## Verification

- reproduced against a clean `origin/main` worktree
- verified at a 1000×500 viewport that the dialog remains within y=32–468
- verified the final command item is fully visible after scrolling
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

## Summary by Sourcery

Constrain the command palette to the viewport and improve scrolling so all results remain accessible.

Bug Fixes:
- Keep the command palette within the dynamic viewport with consistent edge spacing.
- Ensure the final command result remains fully visible above the dialog’s rounded bottom edge.

Enhancements:
- Make the command list the flexible scrolling region within the palette dialog.