### PR TITLE
fix: open relevant bead from desktop notifications

### DIFF
--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -63,12 +63,17 @@ export function useNotificationPrefs() {
   return { prefs, setPrefs, permission, requestPermission };
 }
 
-function fire(title: string, body: string) {
+function fire(title: string, body: string, onActivate: () => void) {
   // Always show an in-app toast; raise a desktop Notification when granted.
   toast(title, { description: body });
   if (typeof window !== "undefined" && "Notification" in window && Notification.permission === "granted") {
     try {
-      new Notification(title, { body });
+      const notification = new Notification(title, { body });
+      notification.onclick = () => {
+        notification.close();
+        window.focus();
+        onActivate();
+      };
     } catch {
       /* some browsers throw if called outside a user gesture — ignore */
     }
@@ -83,7 +88,7 @@ function fire(title: string, body: string) {
  */
 export function useNotificationWatcher(projectId: string) {
   const { data } = useActivity(projectId);
-  const { beads } = useApp();
+  const { beads, openDetail } = useApp();
   const items = data?.items;
 
   const lastSeenRef = React.useRef<string | null>(null);
@@ -107,12 +112,12 @@ export function useNotificationWatcher(projectId: string) {
       if (it.at <= prevSeen) break; // items are newest-first
       if (it.origin !== "agent") continue;
       if (prefs.finished && it.action === "closed") {
-        fire(`🤖 ${it.actor} finished ${it.issueId}`, it.title);
+        fire(`🤖 ${it.actor} finished ${it.issueId}`, it.title, () => openDetail(it.issueId));
       } else if (prefs.blocked && it.action.startsWith("marked Blocked")) {
-        fire(`⛔ ${it.issueId} is blocked`, it.title);
+        fire(`⛔ ${it.issueId} is blocked`, it.title, () => openDetail(it.issueId));
       }
     }
-  }, [items]);
+  }, [items, openDetail]);
 
   // New human-escalations, from the beads list.
   React.useEffect(() => {
@@ -127,7 +132,9 @@ export function useNotificationWatcher(projectId: string) {
     const prefs = loadPrefs();
     if (!prefs.enabled || !prefs.escalation) return;
     for (const b of beads.filter(needsHuman)) {
-      if (!prevSeen.has(b.id)) fire(`🙋 Needs you: ${b.id}`, b.title);
+      if (!prevSeen.has(b.id)) {
+        fire(`🙋 Needs you: ${b.id}`, b.title, () => openDetail(b.id));
+      }
     }
-  }, [beads]);
+  }, [beads, openDetail]);
 }


### PR DESCRIPTION
## Summary

Desktop notifications currently surface the browser when activated, but do not open the bead that caused the notification. Attach an activation handler so the operating system's **Activate** action focuses the app and opens the relevant bead detail drawer.

## Changes

- pass bead-specific activation callbacks into desktop notification creation
- focus the application window and close the desktop notification on activation
- open the corresponding finished, blocked, or escalated bead
- include `openDetail` in the notification watcher effects' dependencies

## Testing

- `npm run lint`
- `npm run build`
- manually created and blocked a test bead, then confirmed clicking **Activate** opened that bead's detail drawer

## Summary by Sourcery

Handle desktop notification activation by focusing the app and opening the corresponding bead detail drawer.

New Features:
- Add activation callbacks to desktop notifications so clicking them opens the relevant bead detail view.

Enhancements:
- Wire notification watcher to use the app-level openDetail handler for finished, blocked, and escalated beads.
- Update notification watcher effect dependencies to include the bead detail opener for correct reactivity.