### PR TITLE
Make views, issue selection, and filters URL-addressable

### DIFF
--- a/app/p/[projectId]/[view]/page.tsx
+++ b/app/p/[projectId]/[view]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { AppShell } from "@/components/app-shell";
 import { projectTitle } from "@/lib/app-title";
 import { getProject } from "@/lib/config";
+import { isView } from "@/lib/views";
 
 type Props = {
-  params: Promise<{ projectId: string }>;
+  params: Promise<{ projectId: string; view: string }>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -15,8 +17,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return project ? { title: projectTitle(project.name) } : {};
 }
 
-export default async function ProjectPage({ params }: Props) {
-  const { projectId } = await params;
+export default async function ProjectViewPage({ params }: Props) {
+  const { projectId, view } = await params;
+  if (!isView(view)) notFound();
+
   return (
     <Suspense fallback={null}>
       <AppShell projectId={projectId} />

--- a/components/activity-view.tsx
+++ b/components/activity-view.tsx
@@ -13,7 +13,7 @@ import { avatarColor, initials, relTime, fmtDateTime } from "@/lib/beads-view";
  * live by the SSE change stream (see useBeadsStream).
  */
 export function ActivityView() {
-  const { projectId, openDetail } = useApp();
+  const { projectId, openDetail, selectedBeadId, selectBead } = useApp();
   const { data, isLoading } = useActivity(projectId);
   const items = data?.items ?? [];
 
@@ -36,8 +36,16 @@ export function ActivityView() {
             {items.map((it) => (
               <li key={it.id}>
                 <button
-                  onClick={() => openDetail(it.issueId)}
-                  className="flex w-full items-start gap-3 rounded-[10px] px-3 py-[10px] text-left hover:bg-[var(--surface-2)]"
+                  data-keyboard-bead-id={it.issueId}
+                  aria-current={selectedBeadId === it.issueId ? "true" : undefined}
+                  onFocus={() => selectBead(it.issueId)}
+                  onClick={() => {
+                    selectBead(it.issueId);
+                    openDetail(it.issueId);
+                  }}
+                  className={`flex w-full items-start gap-3 rounded-[10px] px-3 py-[10px] text-left hover:bg-[var(--surface-2)] focus-visible:outline-none ${
+                    selectedBeadId === it.issueId ? "ring-2 ring-inset ring-[var(--brand)]" : ""
+                  }`}
                 >
                   <span
                     className="mt-[1px] flex h-[26px] w-[26px] flex-shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"

--- a/components/app-context.tsx
+++ b/components/app-context.tsx
@@ -4,6 +4,8 @@ import { type BeadType } from "@/lib/schema";
 import type { Bead } from "@/lib/schema";
 import type { Meta } from "@/lib/api-client";
 
+export type DetailAction = "view" | "edit" | "close";
+
 export type View =
   | "board"
   | "list"
@@ -24,8 +26,10 @@ interface AppContextValue {
   humanAllowlist: string[];
   loading: boolean;
   error?: string;
+  selectedBeadId: string | null;
+  selectBead: (id: string | null) => void;
   /** Open a bead, STARTING A FRESH trail (clears any back history). */
-  openDetail: (id: string) => void;
+  openDetail: (id: string, action?: DetailAction) => void;
   /** Open a bead, PUSHING onto the trail so back returns here. Drawer-internal only. */
   pushDetail: (id: string) => void;
   /** Open the create dialog, optionally presetting the parent and/or the type. */

--- a/components/app-context.tsx
+++ b/components/app-context.tsx
@@ -5,18 +5,7 @@ import type { Bead } from "@/lib/schema";
 import type { Meta } from "@/lib/api-client";
 
 export type DetailAction = "view" | "edit" | "close";
-
-export type View =
-  | "board"
-  | "list"
-  | "epics"
-  | "graph"
-  | "insights"
-  | "activity"
-  | "needsyou"
-  | "achievements"
-  | "publish"
-  | "settings";
+export type { View } from "@/lib/views";
 
 interface AppContextValue {
   projectId: string;

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -2,12 +2,15 @@
 import * as React from "react";
 import { type BeadType } from "@/lib/schema";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useBeads } from "@/hooks/use-beads";
 import { useBeadsStream } from "@/hooks/use-beads-stream";
 import { useLastView } from "@/hooks/use-last-view";
+import { useUrlState } from "@/hooks/use-url-state";
 import { useTheme } from "@/components/theme-provider";
 import { makeIndex } from "@/lib/beads-view";
 import { AppProvider, type DetailAction } from "@/components/app-context";
+import { isView, type View } from "@/lib/views";
 import { Sidebar } from "@/components/sidebar";
 import { Board } from "@/components/board/board";
 import { ListView } from "@/components/list-view";
@@ -25,14 +28,55 @@ import { KeyboardLayer } from "@/components/keyboard-layer";
 import { NotificationWatcher } from "@/components/notification-watcher";
 
 export function AppShell({ projectId }: { projectId: string }) {
-  const [view, setView] = useLastView(projectId);
+  const [lastView, rememberView] = useLastView(projectId);
+  const pathname = usePathname();
+  const { searchParams, updateLocation, updateUrl } = useUrlState();
+  const projectPath = `/p/${encodeURIComponent(projectId)}`;
+  const pathTail = pathname.startsWith(`${projectPath}/`)
+    ? pathname.slice(projectPath.length + 1).split("/")[0]
+    : null;
+  const requestedView = isView(pathTail) ? pathTail : null;
+  const legacyView = searchParams.get("view");
+  const view = requestedView ?? (isView(legacyView) ? legacyView : lastView);
+  const issueId = searchParams.get("issue");
+  const setView = React.useCallback(
+    (nextView: View) => {
+      rememberView(nextView);
+      updateLocation((url) => {
+        url.pathname = `${projectPath}/${nextView}`;
+        url.searchParams.delete("view");
+      });
+    },
+    [projectPath, rememberView, updateLocation],
+  );
+
+  // Upgrade old bare/query-string URLs and repair unknown view segments while
+  // retaining the per-project default used by old bookmarks.
+  React.useEffect(() => {
+    if (requestedView === view && legacyView === null) return;
+    updateLocation((url) => {
+      url.pathname = `${projectPath}/${view}`;
+      url.searchParams.delete("view");
+    }, "replace");
+  }, [legacyView, projectPath, requestedView, updateLocation, view]);
+
+  // Path navigation can also come from browser back/forward, so keep the old
+  // per-project default aligned with whichever route is actually active.
+  React.useEffect(() => {
+    if (requestedView) rememberView(requestedView);
+  }, [rememberView, requestedView]);
+
   const { toggle: toggleTheme } = useTheme();
   // Drawer navigation TRAIL, not a single id: clicking a subtask from its
   // parent used to replace the drawer outright, leaving no way back (GH #15).
-  // The visible bead is the last entry.
-  const [openStack, setOpenStack] = React.useState<string[]>([]);
-  const openId = openStack.length ? openStack[openStack.length - 1] : null;
-  const [selectedBeadId, selectBead] = React.useState<string | null>(null);
+  // The URL's issue is authoritative; the stack only names the drawer's custom
+  // back destination.
+  const [openStack, setOpenStack] = React.useState<string[]>(() =>
+    issueId ? [issueId] : [],
+  );
+  const openId = issueId;
+  const [selectedBeadId, selectBead] = React.useState<string | null>(issueId);
+  const previousUrlIssue = React.useRef(issueId);
   const detailNonce = React.useRef(0);
   const [detailRequest, setDetailRequest] = React.useState<{
     id: string;
@@ -52,37 +96,90 @@ export function AppShell({ projectId }: { projectId: string }) {
   const beads = React.useMemo(() => data?.beads ?? [], [data]);
   const index = React.useMemo(() => makeIndex(beads), [beads]);
 
+  // Back/forward and direct URL navigation drive the drawer and selection.
+  React.useEffect(() => {
+    if (previousUrlIssue.current === issueId) return;
+    previousUrlIssue.current = issueId;
+    selectBead(issueId);
+    setOpenStack((stack) => {
+      if (!issueId) return [];
+      const previousIndex = stack.lastIndexOf(issueId);
+      return previousIndex >= 0 ? stack.slice(0, previousIndex + 1) : [issueId];
+    });
+    if (issueId) {
+      setDetailRequest({
+        id: issueId,
+        action: "view",
+        nonce: (detailNonce.current += 1),
+      });
+    }
+  }, [issueId]);
+
+  const setIssueInUrl = React.useCallback(
+    (id: string | null, mode: "push" | "replace" = "push") => {
+      previousUrlIssue.current = id;
+      updateUrl((params) => {
+        if (id) params.set("issue", id);
+        else params.delete("issue");
+      }, mode);
+    },
+    [updateUrl],
+  );
+
   // RESET. Every caller outside the drawer (board, list, epics, activity,
   // needs-you, palette, assist panel) means "start here", not "continue a trail".
-  const openDetail = React.useCallback((id: string, action: DetailAction = "view") => {
-    selectBead(id);
-    setOpenStack([id]);
-    setDetailRequest({ id, action, nonce: (detailNonce.current += 1) });
-  }, []);
+  const openDetail = React.useCallback(
+    (id: string, action: DetailAction = "view") => {
+      selectBead(id);
+      setOpenStack([id]);
+      setDetailRequest({ id, action, nonce: (detailNonce.current += 1) });
+      setIssueInUrl(id);
+    },
+    [setIssueInUrl],
+  );
   // PUSH. Drawer-internal navigation only, so back can return.
   const MAX_TRAIL = 25;
-  const pushDetail = React.useCallback((id: string) => {
-    selectBead(id);
-    setOpenStack((s) => {
-      if (s[s.length - 1] === id) return s; // re-clicking the current bead is a no-op
-      const next = [...s, id];
-      return next.length > MAX_TRAIL ? next.slice(next.length - MAX_TRAIL) : next;
-    });
-    setDetailRequest({ id, action: "view", nonce: (detailNonce.current += 1) });
-  }, []);
-  const closeDetail = React.useCallback(() => setOpenStack([]), []);
+  const pushDetail = React.useCallback(
+    (id: string) => {
+      selectBead(id);
+      setOpenStack((stack) => {
+        if (stack[stack.length - 1] === id) return stack;
+        const next = [...stack, id];
+        return next.length > MAX_TRAIL
+          ? next.slice(next.length - MAX_TRAIL)
+          : next;
+      });
+      setDetailRequest({
+        id,
+        action: "view",
+        nonce: (detailNonce.current += 1),
+      });
+      setIssueInUrl(id);
+    },
+    [setIssueInUrl],
+  );
+  const closeDetail = React.useCallback(() => {
+    selectBead(null);
+    setOpenStack([]);
+    setIssueInUrl(null);
+  }, [setIssueInUrl]);
   // POP. Skips entries whose bead has since been deleted/archived away, so back
   // can never land on an empty drawer; if nothing valid remains, it closes.
   const backDetail = React.useCallback(() => {
     const next = openStack.slice(0, -1);
     while (next.length && !index.has(next[next.length - 1])) next.pop();
-    const id = next[next.length - 1];
+    const id = next[next.length - 1] ?? null;
     setOpenStack(next);
+    selectBead(id);
     if (id) {
-      selectBead(id);
-      setDetailRequest({ id, action: "view", nonce: (detailNonce.current += 1) });
+      setDetailRequest({
+        id,
+        action: "view",
+        nonce: (detailNonce.current += 1),
+      });
     }
-  }, [index, openStack]);
+    setIssueInUrl(id);
+  }, [index, openStack, setIssueInUrl]);
   // Options object rather than positional args so future presets (assignee,
   // priority) can be added without churning every call site again.
   const openCreate = React.useCallback(
@@ -98,18 +195,28 @@ export function AppShell({ projectId }: { projectId: string }) {
   const clearFocusEpic = React.useCallback(() => setFocusEpic(null), []);
   const openEpic = React.useCallback(
     (epicId: string) => {
+      previousUrlIssue.current = null;
+      selectBead(null);
       setOpenStack([]); // close the detail drawer
-      setView("epics");
+      rememberView("epics");
+      updateLocation((url) => {
+        url.pathname = `${projectPath}/epics`;
+        url.searchParams.delete("view");
+        url.searchParams.delete("issue");
+      });
       setFocusEpic({ id: epicId, nonce: (focusNonce.current += 1) });
     },
-    [setView],
+    [projectPath, rememberView, updateLocation],
   );
 
-  const openCreateFromKeyboard = React.useCallback(() => openCreate(), [openCreate]);
+  const openCreateFromKeyboard = React.useCallback(
+    () => openCreate(),
+    [openCreate],
+  );
   const closeOverlays = React.useCallback(() => {
-    setOpenStack([]);
+    closeDetail();
     setCreate((current) => ({ ...current, open: false }));
-  }, []);
+  }, [closeDetail]);
 
   const errorMessage = error ? (error as Error).message : undefined;
 
@@ -158,7 +265,10 @@ export function AppShell({ projectId }: { projectId: string }) {
               {view === "board" && <Board />}
               {view === "list" && <ListView />}
               {view === "epics" && (
-                <EpicsView focusEpic={focusEpic} onFocusHandledAction={clearFocusEpic} />
+                <EpicsView
+                  focusEpic={focusEpic}
+                  onFocusHandledAction={clearFocusEpic}
+                />
               )}
               {view === "graph" && <GraphView />}
               {view === "insights" && <InsightsView />}
@@ -172,7 +282,9 @@ export function AppShell({ projectId }: { projectId: string }) {
 
           <BeadDetailDrawer
             openId={openId}
-            initialAction={detailRequest?.id === openId ? detailRequest.action : "view"}
+            initialAction={
+              detailRequest?.id === openId ? detailRequest.action : "view"
+            }
             actionNonce={detailRequest?.id === openId ? detailRequest.nonce : 0}
             canGoBack={openStack.length > 1}
             backTo={openStack.length > 1 ? openStack[openStack.length - 2] : null}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -74,6 +74,12 @@ export function AppShell({ projectId }: { projectId: string }) {
   const [openStack, setOpenStack] = React.useState<string[]>(() =>
     issueId ? [issueId] : [],
   );
+  // Mirrors openStack so handlers can pop from the newest value rather than the
+  // one captured when they were last rendered.
+  const openStackRef = React.useRef(openStack);
+  React.useEffect(() => {
+    openStackRef.current = openStack;
+  }, [openStack]);
   const openId = issueId;
   const [selectedBeadId, selectBead] = React.useState<string | null>(issueId);
   const previousUrlIssue = React.useRef(issueId);
@@ -165,11 +171,16 @@ export function AppShell({ projectId }: { projectId: string }) {
   }, [setIssueInUrl]);
   // POP. Skips entries whose bead has since been deleted/archived away, so back
   // can never land on an empty drawer; if nothing valid remains, it closes.
+  // Reads the stack through a ref rather than the render closure, so a burst of
+  // clicks pops one entry each instead of all recomputing from the same stale
+  // array. The URL write has to stay outside a state updater (those must be
+  // pure), hence the ref rather than a functional setOpenStack.
   const backDetail = React.useCallback(() => {
-    const next = openStack.slice(0, -1);
+    const next = openStackRef.current.slice(0, -1);
     while (next.length && !index.has(next[next.length - 1])) next.pop();
-    const id = next[next.length - 1] ?? null;
+    openStackRef.current = next;
     setOpenStack(next);
+    const id = next[next.length - 1] ?? null;
     selectBead(id);
     if (id) {
       setDetailRequest({
@@ -179,7 +190,7 @@ export function AppShell({ projectId }: { projectId: string }) {
       });
     }
     setIssueInUrl(id);
-  }, [index, openStack, setIssueInUrl]);
+  }, [index, setIssueInUrl]);
   // Options object rather than positional args so future presets (assignee,
   // priority) can be added without churning every call site again.
   const openCreate = React.useCallback(

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -82,6 +82,7 @@ export function AppShell({ projectId }: { projectId: string }) {
   // request distinct so clicking the same epic again re-triggers the scroll.
   const [focusEpic, setFocusEpic] = React.useState<{ id: string; nonce: number } | null>(null);
   const focusNonce = React.useRef(0);
+  const clearFocusEpic = React.useCallback(() => setFocusEpic(null), []);
   const openEpic = React.useCallback(
     (epicId: string) => {
       setOpenStack([]); // close the detail drawer
@@ -169,7 +170,9 @@ export function AppShell({ projectId }: { projectId: string }) {
             <>
               {view === "board" && <Board />}
               {view === "list" && <ListView />}
-              {view === "epics" && <EpicsView focusEpic={focusEpic} />}
+              {view === "epics" && (
+                <EpicsView focusEpic={focusEpic} onFocusHandledAction={clearFocusEpic} />
+              )}
               {view === "graph" && <GraphView />}
               {view === "insights" && <InsightsView />}
               {view === "activity" && <ActivityView />}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -7,7 +7,7 @@ import { useBeadsStream } from "@/hooks/use-beads-stream";
 import { useLastView } from "@/hooks/use-last-view";
 import { useTheme } from "@/components/theme-provider";
 import { makeIndex } from "@/lib/beads-view";
-import { AppProvider } from "@/components/app-context";
+import { AppProvider, type DetailAction } from "@/components/app-context";
 import { Sidebar } from "@/components/sidebar";
 import { Board } from "@/components/board/board";
 import { ListView } from "@/components/list-view";
@@ -21,7 +21,7 @@ import { PublishView } from "@/components/publish-view";
 import { SettingsView } from "@/components/settings-view";
 import { BeadDetailDrawer } from "@/components/bead-detail-drawer";
 import { CreateBeadModal } from "@/components/create-bead-modal";
-import { CommandPalette } from "@/components/command-palette";
+import { KeyboardLayer } from "@/components/keyboard-layer";
 import { NotificationWatcher } from "@/components/notification-watcher";
 
 export function AppShell({ projectId }: { projectId: string }) {
@@ -32,7 +32,13 @@ export function AppShell({ projectId }: { projectId: string }) {
   // The visible bead is the last entry.
   const [openStack, setOpenStack] = React.useState<string[]>([]);
   const openId = openStack.length ? openStack[openStack.length - 1] : null;
-  const [palette, setPalette] = React.useState(false);
+  const [selectedBeadId, selectBead] = React.useState<string | null>(null);
+  const detailNonce = React.useRef(0);
+  const [detailRequest, setDetailRequest] = React.useState<{
+    id: string;
+    action: DetailAction;
+    nonce: number;
+  } | null>(null);
   const [create, setCreate] = React.useState<{
     open: boolean;
     parent: string;
@@ -48,28 +54,35 @@ export function AppShell({ projectId }: { projectId: string }) {
 
   // RESET. Every caller outside the drawer (board, list, epics, activity,
   // needs-you, palette, assist panel) means "start here", not "continue a trail".
-  const openDetail = React.useCallback((id: string) => setOpenStack([id]), []);
+  const openDetail = React.useCallback((id: string, action: DetailAction = "view") => {
+    selectBead(id);
+    setOpenStack([id]);
+    setDetailRequest({ id, action, nonce: (detailNonce.current += 1) });
+  }, []);
   // PUSH. Drawer-internal navigation only, so back can return.
   const MAX_TRAIL = 25;
-  const pushDetail = React.useCallback(
-    (id: string) =>
-      setOpenStack((s) => {
-        if (s[s.length - 1] === id) return s; // re-clicking the current bead is a no-op
-        const next = [...s, id];
-        return next.length > MAX_TRAIL ? next.slice(next.length - MAX_TRAIL) : next;
-      }),
-    [],
-  );
+  const pushDetail = React.useCallback((id: string) => {
+    selectBead(id);
+    setOpenStack((s) => {
+      if (s[s.length - 1] === id) return s; // re-clicking the current bead is a no-op
+      const next = [...s, id];
+      return next.length > MAX_TRAIL ? next.slice(next.length - MAX_TRAIL) : next;
+    });
+    setDetailRequest({ id, action: "view", nonce: (detailNonce.current += 1) });
+  }, []);
   const closeDetail = React.useCallback(() => setOpenStack([]), []);
   // POP. Skips entries whose bead has since been deleted/archived away, so back
   // can never land on an empty drawer; if nothing valid remains, it closes.
   const backDetail = React.useCallback(() => {
-    setOpenStack((s) => {
-      const next = s.slice(0, -1);
-      while (next.length && !index.has(next[next.length - 1])) next.pop();
-      return next;
-    });
-  }, [index]);
+    const next = openStack.slice(0, -1);
+    while (next.length && !index.has(next[next.length - 1])) next.pop();
+    const id = next[next.length - 1];
+    setOpenStack(next);
+    if (id) {
+      selectBead(id);
+      setDetailRequest({ id, action: "view", nonce: (detailNonce.current += 1) });
+    }
+  }, [index, openStack]);
   // Options object rather than positional args so future presets (assignee,
   // priority) can be added without churning every call site again.
   const openCreate = React.useCallback(
@@ -92,39 +105,11 @@ export function AppShell({ projectId }: { projectId: string }) {
     [setView],
   );
 
-  // keyboard: Cmd/Ctrl+K = command palette, n = new, / = focus search, t = toggle theme, Esc = close overlays
-  React.useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement)?.tagName?.toLowerCase();
-      const typing = tag === "input" || tag === "textarea" || tag === "select";
-      // Cmd/Ctrl+K toggles the palette — works even while typing in a field.
-      if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
-        e.preventDefault();
-        setPalette((p) => !p);
-        return;
-      }
-      if (e.key === "Escape") {
-        setOpenStack([]);
-        setCreate((c) => ({ ...c, open: false }));
-        return;
-      }
-      if (typing) return;
-      if (e.key === "n") {
-        e.preventDefault();
-        openCreate();
-      }
-      if (e.key === "/") {
-        e.preventDefault();
-        document.querySelector<HTMLInputElement>('input[data-search]')?.focus();
-      }
-      if (e.key === "t" && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        e.preventDefault();
-        toggleTheme();
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [openCreate, toggleTheme]);
+  const openCreateFromKeyboard = React.useCallback(() => openCreate(), [openCreate]);
+  const closeOverlays = React.useCallback(() => {
+    setOpenStack([]);
+    setCreate((current) => ({ ...current, open: false }));
+  }, []);
 
   const errorMessage = error ? (error as Error).message : undefined;
 
@@ -138,6 +123,8 @@ export function AppShell({ projectId }: { projectId: string }) {
         humanAllowlist: data?.meta?.humanAllowlist ?? [],
         loading: isLoading,
         error: errorMessage,
+        selectedBeadId,
+        selectBead,
         openDetail,
         pushDetail,
         openCreate,
@@ -185,6 +172,8 @@ export function AppShell({ projectId }: { projectId: string }) {
 
           <BeadDetailDrawer
             openId={openId}
+            initialAction={detailRequest?.id === openId ? detailRequest.action : "view"}
+            actionNonce={detailRequest?.id === openId ? detailRequest.nonce : 0}
             canGoBack={openStack.length > 1}
             backTo={openStack.length > 1 ? openStack[openStack.length - 2] : null}
             onBack={backDetail}
@@ -200,7 +189,16 @@ export function AppShell({ projectId }: { projectId: string }) {
         onOpenChange={(o) => setCreate((c) => ({ ...c, open: o }))}
       />
 
-      <CommandPalette open={palette} onOpenChange={setPalette} onView={setView} />
+      <KeyboardLayer
+        projectId={projectId}
+        selectedId={selectedBeadId}
+        selectIdAction={selectBead}
+        setViewAction={setView}
+        openDetailAction={openDetail}
+        openCreateAction={openCreateFromKeyboard}
+        closeOverlaysAction={closeOverlays}
+        toggleThemeAction={toggleTheme}
+      />
       <NotificationWatcher projectId={projectId} />
     </AppProvider>
   );

--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -9,7 +9,7 @@ import {
 import { Icon, typeIconName } from "@/components/icons";
 import { OriginBadge, PriorityChip } from "@/components/board/bead-card";
 import { CopyableId } from "@/components/copyable-id";
-import { useApp } from "@/components/app-context";
+import { useApp, type DetailAction } from "@/components/app-context";
 import { useImageDrop } from "@/hooks/use-image-drop";
 import { useResizableWidth } from "@/hooks/use-resizable-width";
 import { DescriptionContent } from "@/components/description-content";
@@ -69,6 +69,8 @@ export function BeadDetailDrawer({
   backTo,
   onBack,
   onClose,
+  initialAction = "view",
+  actionNonce = 0,
 }: {
   openId: string | null;
   /** True when a trail exists behind the current bead (GH #15). */
@@ -77,6 +79,8 @@ export function BeadDetailDrawer({
   backTo?: string | null;
   onBack?: () => void;
   onClose: () => void;
+  initialAction?: DetailAction;
+  actionNonce?: number;
 }) {
   const { index } = useApp();
   const bead = openId ? index.get(openId) : undefined;
@@ -104,8 +108,9 @@ export function BeadDetailDrawer({
         <div className="bd-scroll min-w-0 flex-1 overflow-y-auto">
           {bead ? (
             <DrawerBody
-              key={bead.id}
+              key={`${bead.id}-${actionNonce}`}
               bead={bead}
+              initialAction={initialAction}
               canGoBack={!!canGoBack}
               backTo={backTo ?? null}
               onBack={onBack}
@@ -122,12 +127,14 @@ export function BeadDetailDrawer({
 
 function DrawerBody({
   bead,
+  initialAction,
   canGoBack,
   backTo,
   onBack,
   onClose,
 }: {
   bead: Bead;
+  initialAction: DetailAction;
   canGoBack: boolean;
   backTo: string | null;
   onBack?: () => void;
@@ -158,7 +165,7 @@ function DrawerBody({
   // Closing is the only moment a reason can be recorded — bd offers no way to
   // attach one afterwards — so picking "Closed" opens a skippable composer
   // instead of firing the mutation straight away.
-  const [closing, setClosing] = React.useState(false);
+  const [closing, setClosing] = React.useState(initialAction === "close");
   const [closeDraft, setCloseDraft] = React.useState("");
   const closeRef = React.useRef<HTMLTextAreaElement>(null);
 
@@ -182,7 +189,7 @@ function DrawerBody({
   }, [closing]);
 
   // Inline edit of title + description (with image drop/paste on the textarea).
-  const [editing, setEditing] = React.useState(false);
+  const [editing, setEditing] = React.useState(initialAction === "edit");
   const [previewEdit, setPreviewEdit] = React.useState(false);
   const [titleDraft, setTitleDraft] = React.useState(bead.title);
   const [descDraft, setDescDraft] = React.useState(bead.description ?? "");
@@ -320,6 +327,7 @@ function DrawerBody({
           <>
             <SheetTitle className="sr-only">Edit {bead.id}</SheetTitle>
             <input
+              autoFocus
               value={titleDraft}
               onChange={(e) => setTitleDraft(e.target.value)}
               placeholder="Title"

--- a/components/board/bead-card.tsx
+++ b/components/board/bead-card.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/beads-view";
 
 export function BeadCard({ bead, childCount = 0 }: { bead: Bead; childCount?: number }) {
-  const { index, humanAllowlist, openDetail } = useApp();
+  const { index, humanAllowlist, openDetail, selectedBeadId, selectBead } = useApp();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: bead.id,
   });
@@ -40,15 +40,24 @@ export function BeadCard({ bead, childCount = 0 }: { bead: Bead; childCount?: nu
       ref={setNodeRef}
       {...listeners}
       {...attributes}
-      onClick={() => openDetail(bead.id)}
+      data-keyboard-bead-id={bead.id}
+      aria-current={selectedBeadId === bead.id ? "true" : undefined}
+      onFocus={() => selectBead(bead.id)}
+      onClick={() => {
+        selectBead(bead.id);
+        openDetail(bead.id);
+      }}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
         opacity: isDragging ? 0.4 : 1,
-        boxShadow: "var(--shadow)",
         zIndex: isDragging ? 10 : undefined,
       }}
-      className="flex cursor-pointer touch-none flex-col gap-[9px] rounded-[11px] border border-border bg-[var(--surface)] p-[12px_13px] transition-[border-color,box-shadow] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-lg)]"
+      className={`flex cursor-pointer touch-none flex-col gap-[9px] rounded-[11px] border bg-[var(--surface)] p-[12px_13px] shadow-[var(--shadow)] transition-[border-color] hover:border-2 hover:p-[11px_12px] focus-visible:outline-none ${
+        selectedBeadId === bead.id
+          ? "border-[var(--brand)] hover:border-[var(--text-3)] ring-2 ring-[var(--brand)]/30"
+          : "border-border hover:border-[var(--text-3)]"
+      }`}
     >
       <div className="flex items-center gap-2">
         <span

--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -14,9 +14,11 @@ import { useApp } from "@/components/app-context";
 import { useSetStatus } from "@/hooks/use-beads";
 import { useOrder, useSetOrder } from "@/hooks/use-order";
 import { useBoardPrefs } from "@/hooks/use-board-prefs";
+import { useUrlFilters } from "@/hooks/use-url-filters";
+import { useUrlState } from "@/hooks/use-url-state";
 import { isBlocked, childrenCountMap } from "@/lib/beads-view";
 import { FilterBar } from "@/components/filter-bar";
-import { matchesFilters, emptyFilters, labelOptionsFrom, type Filters } from "@/lib/filters";
+import { matchesFilters, labelOptionsFrom } from "@/lib/filters";
 import { BOARD_COLUMNS as COLUMNS, sortByOrder as sortCards } from "@/lib/board-columns";
 import { Column } from "./column";
 import type { Bead } from "@/lib/schema";
@@ -28,8 +30,9 @@ export function Board() {
   const setOrder = useSetOrder(projectId);
   const { prefs: boardPrefs } = useBoardPrefs();
   const orders = React.useMemo(() => orderData?.orders ?? {}, [orderData]);
-  const [filters, setFilters] = React.useState<Filters>(emptyFilters);
-  const [showArchived, setShowArchived] = React.useState(false);
+  const { filters, setFilters, showArchived, setShowArchived, clearFilters } =
+    useUrlFilters();
+  const { searchParams, updateUrl } = useUrlState();
   // Derived from ALL beads (not the filtered set) so selecting one label
   // doesn't make the remaining options vanish from the dropdown.
   const labelOptions = React.useMemo(() => labelOptionsFrom(beads), [beads]);
@@ -37,7 +40,17 @@ export function Board() {
   // on a large board.
   const childCounts = React.useMemo(() => childrenCountMap(beads), [beads]);
   // Time-window filter for the Done column: null = all, else "closed within N days" (bead nad).
-  const [doneWindow, setDoneWindow] = React.useState<number | null>(null);
+  const doneParam = Number(searchParams.get("done"));
+  const doneWindow = [7, 28, 90, 365].includes(doneParam) ? doneParam : null;
+  const setDoneWindow = React.useCallback(
+    (days: number | null) => {
+      updateUrl((params) => {
+        if (days === null) params.delete("done");
+        else params.set("done", String(days));
+      });
+    },
+    [updateUrl],
+  );
   // Mount-time "now" for the window cutoff — captured once (day-granular, so it
   // needn't tick) and kept out of render to satisfy the no-impure-call rule.
   const [now] = React.useState(() => Date.now());
@@ -134,10 +147,11 @@ export function Board() {
 
         <FilterBar
           filters={filters}
-          onChange={setFilters}
+          onChangeAction={setFilters}
           labelOptions={labelOptions}
           showArchived={showArchived}
-          onShowArchived={setShowArchived}
+          onShowArchivedAction={setShowArchived}
+          onClearAllAction={clearFilters}
         />
 
         <button

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -41,33 +41,51 @@ function pushRecent(id: string) {
   localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
 }
 
-type Page = "root" | "bead" | "status" | "priority" | "projects" | "theme";
+export type PalettePage = "root" | "bead" | "status" | "priority" | "projects" | "theme";
 
 export function CommandPalette({
   open,
-  onOpenChange,
-  onView,
+  onOpenChangeAction,
+  onViewAction,
+  initialPage = "root",
+  initialBeadId = null,
 }: {
   open: boolean;
-  onOpenChange: (o: boolean) => void;
-  onView: (v: View) => void;
+  onOpenChangeAction: (o: boolean) => void;
+  onViewAction: (v: View) => void;
+  initialPage?: PalettePage;
+  initialBeadId?: string | null;
 }) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChangeAction}>
       <DialogContent
         showCloseButton={false}
         className="top-[12%] translate-y-0 gap-0 overflow-hidden rounded-2xl border border-border bg-[var(--surface)] p-0 shadow-[var(--shadow-lg)] sm:max-w-[640px]"
         style={{ width: 640, maxWidth: "94vw" }}
       >
         <DialogTitle className="sr-only">Command palette</DialogTitle>
-        {/* Mounted fresh on each open, so page/search state resets naturally. */}
-        <PaletteBody onView={onView} close={() => onOpenChange(false)} />
+        <PaletteBody
+          onView={onViewAction}
+          close={() => onOpenChangeAction(false)}
+          initialPage={initialPage}
+          initialBeadId={initialBeadId}
+        />
       </DialogContent>
     </Dialog>
   );
 }
 
-function PaletteBody({ onView, close }: { onView: (v: View) => void; close: () => void }) {
+function PaletteBody({
+  onView,
+  close,
+  initialPage,
+  initialBeadId,
+}: {
+  onView: (v: View) => void;
+  close: () => void;
+  initialPage: PalettePage;
+  initialBeadId: string | null;
+}) {
   const { beads, index, openDetail, openCreate, projectId } = useApp();
   const router = useRouter();
   const { mode, setTheme, toggle } = useTheme();
@@ -76,9 +94,9 @@ function PaletteBody({ onView, close }: { onView: (v: View) => void; close: () =
   const { data: projectsData } = useProjects();
   const projects = projectsData?.projects ?? [];
 
-  const [page, setPage] = React.useState<Page>("root");
+  const [page, setPage] = React.useState<PalettePage>(initialPage);
   const [search, setSearch] = React.useState("");
-  const [activeId, setActiveId] = React.useState<string | null>(null);
+  const [activeId, setActiveId] = React.useState<string | null>(initialBeadId);
   const activeBead = activeId ? index.get(activeId) : undefined;
 
   const run = (fn: () => void) => {

--- a/components/epics-view.tsx
+++ b/components/epics-view.tsx
@@ -50,7 +50,14 @@ export function EpicsView({
   focusEpic?: { id: string; nonce: number } | null;
   onFocusHandledAction?: () => void;
 }) {
-  const { beads, humanAllowlist, openCreate, openDetail } = useApp();
+  const {
+    beads,
+    humanAllowlist,
+    openCreate,
+    openDetail,
+    selectedBeadId,
+    selectBead,
+  } = useApp();
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
   const [hideClosed, setHideClosed] = React.useState(true);
   const flashedElement = React.useRef<HTMLElement | null>(null);
@@ -172,17 +179,25 @@ export function EpicsView({
                 <div
                   role="button"
                   tabIndex={0}
+                  data-keyboard-bead-id={e.id}
+                  aria-current={selectedBeadId === e.id ? "true" : undefined}
                   aria-expanded={isOpen}
-                  onClick={() => setExpanded((st) => ({ ...st, [e.id]: !isOpen }))}
+                  onFocus={() => selectBead(e.id)}
+                  onClick={() => {
+                    selectBead(e.id);
+                    setExpanded((st) => ({ ...st, [e.id]: !isOpen }));
+                  }}
                   onKeyDown={(ev) => {
                     if (ev.target !== ev.currentTarget) return;
-                    if (ev.key === "Enter" || ev.key === " ") {
+                    if (ev.key === " ") {
                       ev.preventDefault();
                       setExpanded((st) => ({ ...st, [e.id]: !isOpen }));
                     }
                   }}
                   title={isOpen ? "Hide children" : "Show children"}
-                  className="flex cursor-pointer items-center gap-[14px] p-[16px_18px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
+                  className={`flex cursor-pointer items-center gap-[14px] p-[16px_18px] focus-visible:outline-none ${
+                    selectedBeadId === e.id ? "ring-2 ring-inset ring-[var(--brand)]" : ""
+                  }`}
                 >
                   <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[10px] bg-[var(--brand-weak)] text-[var(--brand)]">
                     <Icon name="target" size={19} />
@@ -271,8 +286,18 @@ export function EpicsView({
                       return (
                         <div
                           key={k.id}
-                          onClick={() => openDetail(k.id)}
-                          className="flex cursor-pointer items-center gap-[11px] rounded-[9px] p-[9px_12px] hover:bg-[var(--surface)]"
+                          role="button"
+                          tabIndex={0}
+                          data-keyboard-bead-id={k.id}
+                          aria-current={selectedBeadId === k.id ? "true" : undefined}
+                          onFocus={() => selectBead(k.id)}
+                          onClick={() => {
+                            selectBead(k.id);
+                            openDetail(k.id);
+                          }}
+                          className={`flex cursor-pointer items-center gap-[11px] rounded-[9px] p-[9px_12px] hover:bg-[var(--surface)] focus-visible:outline-none ${
+                            selectedBeadId === k.id ? "ring-2 ring-inset ring-[var(--brand)]" : ""
+                          }`}
                         >
                           <span
                             className="h-2 w-2 flex-shrink-0 rounded-full"

--- a/components/epics-view.tsx
+++ b/components/epics-view.tsx
@@ -43,10 +43,19 @@ function LabelChips({ labels, max }: { labels: string[]; max: number }) {
   );
 }
 
-export function EpicsView({ focusEpic }: { focusEpic?: { id: string; nonce: number } | null }) {
+export function EpicsView({
+  focusEpic,
+  onFocusHandledAction,
+}: {
+  focusEpic?: { id: string; nonce: number } | null;
+  onFocusHandledAction?: () => void;
+}) {
   const { beads, humanAllowlist, openCreate, openDetail } = useApp();
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
   const [hideClosed, setHideClosed] = React.useState(true);
+  const flashedElement = React.useRef<HTMLElement | null>(null);
+  const focusFrame = React.useRef<number | null>(null);
+  const flashTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   // Explicitly ordered: open before closed, then priority ascending, then id
   // for stability. Previously a bare .filter(), so the apparent priority order
   // was incidental to whatever `bd export` returned.
@@ -59,24 +68,50 @@ export function EpicsView({ focusEpic }: { focusEpic?: { id: string; nonce: numb
         a.id.localeCompare(b.id),
     );
   // "Filter out closed" (bead 8vm): hide closed epics (and closed children below).
-  // Progress % still counts all children, so it stays accurate. A focused epic —
-  // jumped to from a bead's detail drawer (bead 55b) — is always shown.
+  // Progress % still counts all children, so it stays accurate. A newly focused
+  // closed epic is included for the first render; the focus effect then turns
+  // this filter off so the control accurately reflects what is visible.
   const epics = allEpics.filter(
     (e) => !hideClosed || e.status !== "closed" || e.id === focusEpic?.id,
   );
 
-  // On a focus request, scroll the target epic into view and flash it. DOM-only
-  // side effects (no setState) keep this a clean effect; the nonce re-triggers it
-  // even when the same epic is requested twice.
+  // Consume each focus request after scrolling. Keeping a handled request in
+  // AppShell made its closed-epic exception permanent, so "Hide closed" could
+  // never hide that epic and returning to this view focused it again.
   React.useEffect(() => {
     if (!focusEpic) return;
     const el = document.querySelector<HTMLElement>(`[data-epic-id="${CSS.escape(focusEpic.id)}"]`);
     if (!el) return;
+
+    const focusedEpic = beads.find((bead) => bead.id === focusEpic.id);
+    if (focusFrame.current !== null) cancelAnimationFrame(focusFrame.current);
+    focusFrame.current = requestAnimationFrame(() => {
+      if (focusedEpic?.status === "closed") setHideClosed(false);
+      setExpanded((state) => ({ ...state, [focusEpic.id]: true }));
+      onFocusHandledAction?.();
+      focusFrame.current = null;
+    });
+
+    if (flashTimeout.current) clearTimeout(flashTimeout.current);
+    flashedElement.current?.classList.remove("epic-flash");
+    flashedElement.current = el;
     el.scrollIntoView({ behavior: "smooth", block: "start" });
     el.classList.add("epic-flash");
-    const t = setTimeout(() => el.classList.remove("epic-flash"), 1600);
-    return () => clearTimeout(t);
-  }, [focusEpic]);
+    flashTimeout.current = setTimeout(() => {
+      el.classList.remove("epic-flash");
+      flashedElement.current = null;
+      flashTimeout.current = null;
+    }, 1600);
+  }, [beads, focusEpic, onFocusHandledAction]);
+
+  React.useEffect(
+    () => () => {
+      if (focusFrame.current !== null) cancelAnimationFrame(focusFrame.current);
+      if (flashTimeout.current) clearTimeout(flashTimeout.current);
+      flashedElement.current?.classList.remove("epic-flash");
+    },
+    [],
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/components/filter-bar.tsx
+++ b/components/filter-bar.tsx
@@ -1,10 +1,9 @@
 "use client";
-import * as React from "react";
 import { Icon } from "@/components/icons";
 import { MultiSelectFilter, type FilterOption } from "@/components/multi-select-filter";
 import { typeLabel, statusLabel, prioLabel } from "@/lib/beads-view";
 import { BEAD_TYPES, BEAD_STATUSES } from "@/lib/schema";
-import { type Filters, emptyFilters, toggleStr, toggleNum } from "@/lib/filters";
+import { type Filters, toggleStr, toggleNum } from "@/lib/filters";
 
 /**
  * Search + multi-select facet filters, shared by the Board and List views so
@@ -15,18 +14,20 @@ import { type Filters, emptyFilters, toggleStr, toggleNum } from "@/lib/filters"
  */
 export function FilterBar({
   filters,
-  onChange,
+  onChangeAction,
   labelOptions,
   showArchived,
-  onShowArchived,
+  onShowArchivedAction,
+  onClearAllAction,
 }: {
   filters: Filters;
-  onChange: (f: Filters) => void;
+  onChangeAction: (f: Filters) => void;
   labelOptions: FilterOption[];
   showArchived: boolean;
-  onShowArchived: (v: boolean) => void;
+  onShowArchivedAction: (v: boolean) => void;
+  onClearAllAction: () => void;
 }) {
-  const set = (patch: Partial<Filters>) => onChange({ ...filters, ...patch });
+  const set = (patch: Partial<Filters>) => onChangeAction({ ...filters, ...patch });
 
   // Count active filters (each non-empty facet + a non-empty search + archived)
   // so we can offer a one-click reset (bead 3it).
@@ -38,10 +39,7 @@ export function FilterBar({
     (filters.labels.length ? 1 : 0) +
     (filters.search.trim() ? 1 : 0) +
     (showArchived ? 1 : 0);
-  const clearAll = () => {
-    onChange(emptyFilters);
-    onShowArchived(false);
-  };
+  const clearAll = () => onClearAllAction();
 
   return (
     <>
@@ -98,7 +96,7 @@ export function FilterBar({
           onClear={() => set({ origin: [] })}
         />
         <button
-          onClick={() => onShowArchived(!showArchived)}
+          onClick={() => onShowArchivedAction(!showArchived)}
           title="Toggle archived"
           className="flex h-9 items-center gap-[6px] rounded-[9px] px-[11px] text-[12.5px] font-medium"
           style={{

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -23,10 +23,23 @@ type BeadNodeData = { bead: Bead; onOpen: (id: string) => void };
 
 function BeadNode({ data }: NodeProps) {
   const { bead, onOpen } = data as unknown as BeadNodeData;
+  const { selectedBeadId, selectBead } = useApp();
   return (
     <div
-      onClick={() => onOpen(bead.id)}
-      className="w-[150px] cursor-pointer rounded-[11px] border border-border bg-[var(--surface)] p-[9px_11px] shadow-[var(--shadow)] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-lg)]"
+      role="button"
+      tabIndex={0}
+      data-keyboard-bead-id={bead.id}
+      aria-current={selectedBeadId === bead.id ? "true" : undefined}
+      onFocus={() => selectBead(bead.id)}
+      onClick={() => {
+        selectBead(bead.id);
+        onOpen(bead.id);
+      }}
+      className={`w-[150px] cursor-pointer rounded-[11px] border bg-[var(--surface)] p-[9px_11px] shadow-[var(--shadow)] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-lg)] focus-visible:outline-none ${
+        selectedBeadId === bead.id
+          ? "border-[var(--brand)] ring-2 ring-[var(--brand)]/30"
+          : "border-border"
+      }`}
     >
       <Handle type="target" position={Position.Top} style={{ background: "var(--text-3)" }} />
       <div className="mb-[5px] flex items-center gap-[6px]">

--- a/components/keyboard-help-dialog.tsx
+++ b/components/keyboard-help-dialog.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import { KEYBOARD_SHORTCUT_GROUPS } from "@/lib/keyboard-shortcuts";
+
+function ShortcutKeys({ keys, sequence }: { keys: string[]; sequence?: boolean }) {
+  return (
+    <span className="flex flex-shrink-0 items-center gap-1">
+      {keys.map((key, index) => (
+        <span key={`${key}-${index}`} className="contents">
+          {index > 0 && (
+            <span className="text-[10px] text-[var(--text-3)]">
+              {sequence ? "then" : "+"}
+            </span>
+          )}
+          <kbd className="min-w-7 rounded-md border border-border bg-[var(--surface-2)] px-2 py-1 text-center font-mono text-[11px] font-semibold text-[var(--text-2)] shadow-[var(--shadow)]">
+            {key}
+          </kbd>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function KeyboardHelpDialog({
+  open,
+  onOpenChangeAction,
+}: {
+  open: boolean;
+  onOpenChangeAction: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChangeAction}>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden border border-border bg-[var(--surface)] p-0 shadow-[var(--shadow-lg)] sm:max-w-[760px]">
+        <div className="border-b border-border px-6 py-5">
+          <DialogTitle className="text-lg font-semibold">Keyboard shortcuts</DialogTitle>
+          <DialogDescription className="mt-1 text-[12.5px] text-[var(--text-3)]">
+            Vim-style navigation is disabled while typing. View and repository shortcuts are
+            two-key sequences.
+          </DialogDescription>
+        </div>
+        <div className="bd-scroll grid min-h-0 grid-cols-1 gap-6 overflow-y-auto px-6 py-5 md:grid-cols-2">
+          {KEYBOARD_SHORTCUT_GROUPS.map((group) => (
+            <section key={group.topic}>
+              <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-[.08em] text-[var(--text-3)]">
+                {group.topic}
+              </h2>
+              <div className="flex flex-col gap-1">
+                {group.shortcuts.map((shortcut) => (
+                  <div
+                    key={`${group.topic}-${shortcut.keys.join("-")}-${shortcut.label}`}
+                    className="flex min-h-9 items-center justify-between gap-4 rounded-lg px-2 py-1.5 hover:bg-[var(--surface-2)]"
+                  >
+                    <span className="text-[12.5px] text-[var(--text-2)]">{shortcut.label}</span>
+                    <ShortcutKeys keys={shortcut.keys} sequence={shortcut.sequence} />
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/keyboard-help-dialog.tsx
+++ b/components/keyboard-help-dialog.tsx
@@ -3,7 +3,7 @@
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { KEYBOARD_SHORTCUT_GROUPS } from "@/lib/keyboard-shortcuts";
 
-function ShortcutKeys({ keys, sequence }: { keys: string[]; sequence?: boolean }) {
+export function ShortcutKeys({ keys, sequence }: { keys: string[]; sequence?: boolean }) {
   return (
     <span className="flex flex-shrink-0 items-center gap-1">
       {keys.map((key, index) => (

--- a/components/keyboard-layer.tsx
+++ b/components/keyboard-layer.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as React from "react";
+import type { DetailAction, View } from "@/components/app-context";
+import { CommandPalette, type PalettePage } from "@/components/command-palette";
+import { KeyboardHelpDialog } from "@/components/keyboard-help-dialog";
+import { useAppKeyboardShortcuts } from "@/hooks/use-app-keyboard";
+
+export function KeyboardLayer({
+  projectId,
+  selectedId,
+  selectIdAction,
+  setViewAction,
+  openDetailAction,
+  openCreateAction,
+  closeOverlaysAction,
+  toggleThemeAction,
+}: {
+  projectId: string;
+  selectedId: string | null;
+  selectIdAction: (id: string | null) => void;
+  setViewAction: (view: View) => void;
+  openDetailAction: (id: string, action?: DetailAction) => void;
+  openCreateAction: () => void;
+  closeOverlaysAction: () => void;
+  toggleThemeAction: () => void;
+}) {
+  const [helpOpen, setHelpOpen] = React.useState(false);
+  const paletteNonce = React.useRef(0);
+  const [paletteRequest, setPaletteRequest] = React.useState<{
+    open: boolean;
+    page: PalettePage;
+    beadId: string | null;
+    nonce: number;
+  }>({ open: false, page: "root", beadId: null, nonce: 0 });
+
+  const openPalette = React.useCallback((page: PalettePage = "root", beadId?: string) => {
+    setPaletteRequest((current) => ({
+      open: page === "root" && !beadId && current.open ? false : true,
+      page,
+      beadId: beadId ?? null,
+      nonce: (paletteNonce.current += 1),
+    }));
+  }, []);
+  const closeAll = React.useCallback(() => {
+    setPaletteRequest((current) => ({ ...current, open: false }));
+    setHelpOpen(false);
+    closeOverlaysAction();
+  }, [closeOverlaysAction]);
+
+  const actions = React.useMemo(
+    () => ({
+      projectId,
+      selectedId,
+      selectId: selectIdAction,
+      setView: setViewAction,
+      openDetail: openDetailAction,
+      openCreate: openCreateAction,
+      openPalette,
+      openHelp: () => setHelpOpen(true),
+      closeOverlays: closeAll,
+      toggleTheme: toggleThemeAction,
+    }),
+    [
+      projectId,
+      selectedId,
+      selectIdAction,
+      setViewAction,
+      openDetailAction,
+      openCreateAction,
+      openPalette,
+      closeAll,
+      toggleThemeAction,
+    ],
+  );
+  useAppKeyboardShortcuts(actions);
+
+  return (
+    <>
+      <CommandPalette
+        key={paletteRequest.nonce}
+        open={paletteRequest.open}
+        onOpenChangeAction={(open) =>
+          setPaletteRequest((current) => ({ ...current, open }))
+        }
+        onViewAction={setViewAction}
+        initialPage={paletteRequest.page}
+        initialBeadId={paletteRequest.beadId}
+      />
+      <KeyboardHelpDialog open={helpOpen} onOpenChangeAction={setHelpOpen} />
+    </>
+  );
+}

--- a/components/list-view.tsx
+++ b/components/list-view.tsx
@@ -246,6 +246,7 @@ function Row({
   childCount: number;
   humanAllowlist: string[];
 }) {
+  const { selectedBeadId, selectBead } = useApp();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: bead.id,
   });
@@ -265,7 +266,13 @@ function Row({
       {...attributes}
       role="button"
       tabIndex={0}
-      onClick={onOpen}
+      data-keyboard-bead-id={bead.id}
+      aria-current={selectedBeadId === bead.id ? "true" : undefined}
+      onFocus={() => selectBead(bead.id)}
+      onClick={() => {
+        selectBead(bead.id);
+        onOpen();
+      }}
       onKeyDown={openFromKeyboard}
       style={{
         transform: CSS.Transform.toString(transform),
@@ -273,7 +280,11 @@ function Row({
         opacity: isDragging ? 0.4 : 1,
         zIndex: isDragging ? 10 : undefined,
       }}
-      className="flex w-full cursor-pointer touch-none items-center gap-3 rounded-[10px] border border-border bg-[var(--surface)] px-[13px] py-[9px] text-left transition-[border-color,box-shadow] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
+      className={`flex w-full cursor-pointer touch-none items-center gap-3 rounded-[10px] border bg-[var(--surface)] px-[13px] py-[9px] text-left transition-[border-color,box-shadow] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)] focus-visible:outline-none ${
+        selectedBeadId === bead.id
+          ? "border-[var(--brand)] ring-2 ring-[var(--brand)]/30"
+          : "border-border"
+      }`}
     >
       <span
         className="h-[9px] w-[9px] flex-shrink-0 rounded-full"

--- a/components/list-view.tsx
+++ b/components/list-view.tsx
@@ -22,7 +22,8 @@ import { CopyableId } from "@/components/copyable-id";
 import { FilterBar } from "@/components/filter-bar";
 import { useOrder, useSetOrder } from "@/hooks/use-order";
 import { useSetStatus } from "@/hooks/use-beads";
-import { matchesFilters, emptyFilters, labelOptionsFrom, type Filters } from "@/lib/filters";
+import { useUrlFilters } from "@/hooks/use-url-filters";
+import { matchesFilters, labelOptionsFrom } from "@/lib/filters";
 import { BOARD_COLUMNS, COLUMN_ORDER, colOf } from "@/lib/board-columns";
 import { beadOrigin, originTitle } from "@/lib/attribution";
 import {
@@ -60,8 +61,8 @@ export function ListView() {
   const setOrder = useSetOrder(projectId);
   const orders = React.useMemo(() => orderData?.orders ?? {}, [orderData]);
 
-  const [filters, setFilters] = React.useState<Filters>(emptyFilters);
-  const [showArchived, setShowArchived] = React.useState(false);
+  const { filters, setFilters, showArchived, setShowArchived, clearFilters } =
+    useUrlFilters();
   // Derived from ALL beads (not the filtered set) so selecting one label
   // doesn't make the remaining options vanish from the dropdown.
   const labelOptions = React.useMemo(() => labelOptionsFrom(beads), [beads]);
@@ -157,10 +158,11 @@ export function ListView() {
 
         <FilterBar
           filters={filters}
-          onChange={setFilters}
+          onChangeAction={setFilters}
           labelOptions={labelOptions}
           showArchived={showArchived}
-          onShowArchived={setShowArchived}
+          onShowArchivedAction={setShowArchived}
+          onClearAllAction={clearFilters}
         />
 
         <button

--- a/components/needs-you-view.tsx
+++ b/components/needs-you-view.tsx
@@ -70,13 +70,24 @@ export function NeedsYouView() {
  * resolves it and unblocks every bead depending on it.
  */
 function GateCard({ gate }: { gate: Bead }) {
-  const { beads, openDetail } = useApp();
+  const { beads, openDetail, selectedBeadId, selectBead } = useApp();
   const setStatus = useSetStatus();
   const blocks = React.useMemo(() => gateBlocks(gate.id, beads), [gate.id, beads]);
   const busy = setStatus.isPending;
 
   return (
-    <div className="rounded-[12px] border border-border bg-[var(--surface)] p-4">
+    <div
+      role="button"
+      tabIndex={0}
+      data-keyboard-bead-id={gate.id}
+      aria-current={selectedBeadId === gate.id ? "true" : undefined}
+      onFocus={() => selectBead(gate.id)}
+      className={`rounded-[12px] border bg-[var(--surface)] p-4 focus-visible:outline-none ${
+        selectedBeadId === gate.id
+          ? "border-[var(--brand)] ring-2 ring-[var(--brand)]/30"
+          : "border-border"
+      }`}
+    >
       <div className="mb-1 flex items-center gap-2">
         <Icon name="gate" size={15} style={{ color: "var(--brand)" }} />
         <button
@@ -136,7 +147,7 @@ function GateCard({ gate }: { gate: Bead }) {
 }
 
 function NeedsYouCard({ bead }: { bead: Bead }) {
-  const { humanAllowlist, openDetail } = useApp();
+  const { humanAllowlist, openDetail, selectedBeadId, selectBead } = useApp();
   const respond = useRespondHuman();
   const dismiss = useDismissHuman();
   const [text, setText] = React.useState("");
@@ -144,7 +155,18 @@ function NeedsYouCard({ bead }: { bead: Bead }) {
   const busy = respond.isPending || dismiss.isPending;
 
   return (
-    <div className="rounded-[12px] border border-border bg-[var(--surface)] p-4">
+    <div
+      role="button"
+      tabIndex={0}
+      data-keyboard-bead-id={bead.id}
+      aria-current={selectedBeadId === bead.id ? "true" : undefined}
+      onFocus={() => selectBead(bead.id)}
+      className={`rounded-[12px] border bg-[var(--surface)] p-4 focus-visible:outline-none ${
+        selectedBeadId === bead.id
+          ? "border-[var(--brand)] ring-2 ring-[var(--brand)]/30"
+          : "border-border"
+      }`}
+    >
       <div className="mb-1 flex items-center gap-2">
         <Icon name={typeIconName(bead.issue_type)} size={14} style={{ color: typeColor(bead.issue_type) }} />
         <button

--- a/components/settings-view.tsx
+++ b/components/settings-view.tsx
@@ -10,6 +10,7 @@ import { api, type DoctorResponse } from "@/lib/api-client";
 import { useNotificationPrefs, type NotifPrefs } from "@/hooks/use-notifications";
 import { useBoardPrefs } from "@/hooks/use-board-prefs";
 import { KEYBOARD_SHORTCUT_GROUPS } from "@/lib/keyboard-shortcuts";
+import { KeyboardHelpDialog, ShortcutKeys } from "@/components/keyboard-help-dialog";
 
 const inputClass =
   "h-[38px] rounded-[9px] border border-border bg-[var(--surface-2)] px-3 text-[12.5px] text-[var(--text)] outline-none focus:border-[var(--brand)]";
@@ -222,21 +223,7 @@ function SettingsForm({ data }: { data: DoctorResponse }) {
 
       <GamificationCard />
 
-      <Card title="Keyboard shortcuts">
-        <div className="grid grid-cols-2 gap-x-6 gap-y-3">
-          {KEYBOARD_SHORTCUT_GROUPS.map((group) => (
-            <div key={group.topic}>
-              <div className="text-[12.5px] font-[550] text-[var(--text-2)]">{group.topic}</div>
-              <div className="mt-1 text-[11.5px] text-[var(--text-3)]">
-                {group.shortcuts.length} bindings
-              </div>
-            </div>
-          ))}
-        </div>
-        <div className="text-[11.5px] text-[var(--text-3)]">
-          Press <kbd className="rounded border border-border bg-[var(--surface-2)] px-1.5 py-0.5 font-mono">?</kbd> anywhere outside a field to see the complete grouped reference.
-        </div>
-      </Card>
+      <KeyboardShortcutsCard />
 
       <div className="flex justify-end">
         <button
@@ -250,6 +237,50 @@ function SettingsForm({ data }: { data: DoctorResponse }) {
         </button>
       </div>
     </div>
+  );
+}
+
+function KeyboardShortcutsCard() {
+  const [helpOpen, setHelpOpen] = React.useState(false);
+  return (
+    <Card title="Keyboard shortcuts">
+      <div className="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-2">
+        {KEYBOARD_SHORTCUT_GROUPS.map((group) => (
+          <section key={group.topic}>
+            <h3 className="mb-1.5 text-[11px] font-semibold uppercase tracking-[.08em] text-[var(--text-3)]">
+              {group.topic}
+            </h3>
+            <div className="flex flex-col gap-1">
+              {group.shortcuts.map((shortcut) => (
+                <div
+                  key={`${group.topic}-${shortcut.keys.join("-")}-${shortcut.label}`}
+                  className="flex min-h-7 items-center justify-between gap-4"
+                >
+                  <span className="text-[12.5px] text-[var(--text-2)]">{shortcut.label}</span>
+                  <ShortcutKeys keys={shortcut.keys} sequence={shortcut.sequence} />
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-[11.5px] text-[var(--text-3)]">
+          Shortcuts are disabled while typing in a field. Press{" "}
+          <kbd className="rounded border border-border bg-[var(--surface-2)] px-1.5 py-0.5 font-mono">
+            ?
+          </kbd>{" "}
+          anywhere outside a field for the same reference.
+        </span>
+        <button
+          onClick={() => setHelpOpen(true)}
+          className="h-[30px] flex-shrink-0 rounded-[8px] border border-border px-3 text-[12.5px] text-[var(--text-2)] hover:bg-[var(--surface-2)]"
+        >
+          Open reference
+        </button>
+      </div>
+      <KeyboardHelpDialog open={helpOpen} onOpenChangeAction={setHelpOpen} />
+    </Card>
   );
 }
 

--- a/components/settings-view.tsx
+++ b/components/settings-view.tsx
@@ -9,6 +9,7 @@ import { useApp } from "@/components/app-context";
 import { api, type DoctorResponse } from "@/lib/api-client";
 import { useNotificationPrefs, type NotifPrefs } from "@/hooks/use-notifications";
 import { useBoardPrefs } from "@/hooks/use-board-prefs";
+import { KEYBOARD_SHORTCUT_GROUPS } from "@/lib/keyboard-shortcuts";
 
 const inputClass =
   "h-[38px] rounded-[9px] border border-border bg-[var(--surface-2)] px-3 text-[12.5px] text-[var(--text)] outline-none focus:border-[var(--brand)]";
@@ -222,31 +223,18 @@ function SettingsForm({ data }: { data: DoctorResponse }) {
       <GamificationCard />
 
       <Card title="Keyboard shortcuts">
-        <div className="flex flex-col gap-[10px]">
-          {[
-            { keys: ["⌘", "K"], label: "Open the command palette" },
-            { keys: ["N"], label: "Create a new bead" },
-            { keys: ["/"], label: "Focus the search box" },
-            { keys: ["T"], label: "Toggle light / dark theme" },
-            { keys: ["Esc"], label: "Close the open drawer or dialog" },
-          ].map((s) => (
-            <div key={s.label} className="flex items-center justify-between">
-              <span className="text-[13px] text-[var(--text-2)]">{s.label}</span>
-              <span className="flex items-center gap-1">
-                {s.keys.map((k) => (
-                  <kbd
-                    key={k}
-                    className="rounded-md border border-border bg-[var(--surface-2)] px-[8px] py-[3px] font-mono text-[12px] text-[var(--text-2)] shadow-[var(--shadow)]"
-                  >
-                    {k}
-                  </kbd>
-                ))}
-              </span>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+          {KEYBOARD_SHORTCUT_GROUPS.map((group) => (
+            <div key={group.topic}>
+              <div className="text-[12.5px] font-[550] text-[var(--text-2)]">{group.topic}</div>
+              <div className="mt-1 text-[11.5px] text-[var(--text-3)]">
+                {group.shortcuts.length} bindings
+              </div>
             </div>
           ))}
         </div>
         <div className="text-[11.5px] text-[var(--text-3)]">
-          Shortcuts are disabled while typing in a field.
+          Press <kbd className="rounded border border-border bg-[var(--surface-2)] px-1.5 py-0.5 font-mono">?</kbd> anywhere outside a field to see the complete grouped reference.
         </div>
       </Card>
 

--- a/hooks/use-app-keyboard.ts
+++ b/hooks/use-app-keyboard.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import type { View, DetailAction } from "@/components/app-context";
+import { useProjects } from "@/hooks/use-projects";
+import { VIEW_KEY_BINDINGS } from "@/lib/keyboard-shortcuts";
+
+const ITEM_SELECTOR = "[data-keyboard-bead-id]";
+const CHORD_TIMEOUT_MS = 900;
+
+type PalettePage = "root" | "status" | "priority" | "projects";
+
+interface KeyboardActions {
+  projectId: string;
+  selectedId: string | null;
+  selectId: (id: string | null) => void;
+  setView: (view: View) => void;
+  openDetail: (id: string, action?: DetailAction) => void;
+  openCreate: () => void;
+  openPalette: (page?: PalettePage, beadId?: string) => void;
+  openHelp: () => void;
+  closeOverlays: () => void;
+  toggleTheme: () => void;
+}
+
+function isTyping(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select" || target.isContentEditable;
+}
+
+function isInteractive(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return !!target.closest("button, a, input, textarea, select") && !target.matches(ITEM_SELECTOR);
+}
+
+function hasOpenOverlay(): boolean {
+  return !!document.querySelector('[data-slot="dialog-content"], [data-slot="sheet-content"]');
+}
+
+function visibleItems(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(ITEM_SELECTOR)).filter((element) => {
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+  });
+}
+
+function itemId(element: HTMLElement): string | null {
+  return element.dataset.keyboardBeadId ?? null;
+}
+
+function focusItem(element: HTMLElement, selectId: (id: string | null) => void) {
+  const id = itemId(element);
+  if (!id) return;
+  selectId(id);
+  element.focus({ preventScroll: true });
+  element.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
+}
+
+function moveLinear(direction: 1 | -1, selectedId: string | null, selectId: KeyboardActions["selectId"]) {
+  const items = visibleItems();
+  if (items.length === 0) return;
+  const focused = document.activeElement instanceof HTMLElement ? items.indexOf(document.activeElement) : -1;
+  const current = focused !== -1 ? focused : items.findIndex((element) => itemId(element) === selectedId);
+  const next = current === -1 ? (direction === 1 ? 0 : items.length - 1) : current + direction;
+  focusItem(items[Math.max(0, Math.min(items.length - 1, next))], selectId);
+}
+
+function moveHorizontal(direction: 1 | -1, selectedId: string | null, selectId: KeyboardActions["selectId"]) {
+  const items = visibleItems();
+  if (items.length === 0) return;
+  const focused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const current = (focused && items.includes(focused) ? focused : null) ??
+    items.find((element) => itemId(element) === selectedId) ??
+    items[0];
+  const rect = current.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+  const candidates = items
+    .filter((element) => element !== current)
+    .map((element) => {
+      const candidate = element.getBoundingClientRect();
+      const dx = candidate.left + candidate.width / 2 - x;
+      const dy = candidate.top + candidate.height / 2 - y;
+      return { element, dx, score: Math.abs(dx) + Math.abs(dy) * 2 };
+    })
+    .filter(({ dx }) => (direction === 1 ? dx > 8 : dx < -8))
+    .sort((a, b) => a.score - b.score);
+  if (candidates[0]) focusItem(candidates[0].element, selectId);
+}
+
+function selectedOrFirst(selectedId: string | null, selectId: KeyboardActions["selectId"]): string | null {
+  const items = visibleItems();
+  const focused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const selected = (focused && items.includes(focused) ? focused : null) ??
+    items.find((element) => itemId(element) === selectedId) ??
+    items[0];
+  if (!selected) return null;
+  const id = itemId(selected);
+  if (id !== selectedId) focusItem(selected, selectId);
+  return id;
+}
+
+function runChord(
+  key: string,
+  actions: KeyboardActions,
+  cycleProject: (direction: 1 | -1) => void,
+): boolean {
+  const view = VIEW_KEY_BINDINGS[key];
+  if (view) {
+    actions.selectId(null);
+    actions.setView(view);
+    return true;
+  }
+  if (key === "r") {
+    actions.openPalette("projects");
+    return true;
+  }
+  if (key === "[" || key === "]") {
+    cycleProject(key === "]" ? 1 : -1);
+    return true;
+  }
+  return false;
+}
+
+function runGlobalShortcut(key: string, actions: KeyboardActions): boolean {
+  if (key === "?") actions.openHelp();
+  else if (key === "/") document.querySelector<HTMLInputElement>("input[data-search]")?.focus();
+  else if (key === "n") actions.openCreate();
+  else if (key === "t") actions.toggleTheme();
+  else return false;
+  return true;
+}
+
+function runMovementShortcut(key: string, actions: KeyboardActions): boolean {
+  if (key === "j" || key === "k") {
+    moveLinear(key === "j" ? 1 : -1, actions.selectedId, actions.selectId);
+  } else if (key === "h" || key === "l") {
+    moveHorizontal(key === "l" ? 1 : -1, actions.selectedId, actions.selectId);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+function runIssueShortcut(key: string, actions: KeyboardActions): boolean {
+  if (!["Enter", "o", "e", "c", "s", "p"].includes(key)) return false;
+  const id = selectedOrFirst(actions.selectedId, actions.selectId);
+  if (!id) return false;
+  if (key === "Enter" || key === "o") actions.openDetail(id);
+  else if (key === "e") actions.openDetail(id, "edit");
+  else if (key === "c") actions.openDetail(id, "close");
+  else actions.openPalette(key === "s" ? "status" : "priority", id);
+  return true;
+}
+
+export function useAppKeyboardShortcuts(actions: KeyboardActions) {
+  const router = useRouter();
+  const { data } = useProjects();
+  const projects = React.useMemo(() => data?.projects ?? [], [data]);
+  const pendingChordAt = React.useRef(0);
+
+  const cycleProject = React.useCallback(
+    (direction: 1 | -1) => {
+      if (projects.length === 0) return;
+      const current = projects.findIndex((project) => project.id === actions.projectId);
+      const next = current === -1 ? 0 : (current + direction + projects.length) % projects.length;
+      router.push(`/p/${projects[next].id}`);
+    },
+    [actions.projectId, projects, router],
+  );
+
+  React.useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      if ((event.metaKey || event.ctrlKey) && key === "k") {
+        event.preventDefault();
+        actions.openPalette();
+        return;
+      }
+      if (key === "Escape") {
+        pendingChordAt.current = 0;
+        if (!hasOpenOverlay()) actions.closeOverlays();
+        return;
+      }
+      if (
+        isTyping(event.target) ||
+        isInteractive(event.target) ||
+        hasOpenOverlay() ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.repeat
+      ) {
+        return;
+      }
+      if (pendingChordAt.current > Date.now()) {
+        pendingChordAt.current = 0;
+        if (runChord(key, actions, cycleProject)) {
+          event.preventDefault();
+          return;
+        }
+      }
+      if (key === "g") {
+        event.preventDefault();
+        pendingChordAt.current = Date.now() + CHORD_TIMEOUT_MS;
+        return;
+      }
+      if (
+        runGlobalShortcut(key, actions) ||
+        runMovementShortcut(key, actions) ||
+        runIssueShortcut(key, actions)
+      ) {
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [actions, cycleProject]);
+}

--- a/hooks/use-last-view.ts
+++ b/hooks/use-last-view.ts
@@ -1,20 +1,6 @@
 "use client";
 import * as React from "react";
-import type { View } from "@/components/app-context";
-
-const VIEWS: View[] = [
-  "board",
-  "list",
-  "epics",
-  "graph",
-  "insights",
-  "activity",
-  "needsyou",
-  "achievements",
-  "publish",
-  "settings",
-];
-const isView = (v: string | null): v is View => v != null && (VIEWS as string[]).includes(v);
+import { isView, type View } from "@/lib/views";
 const keyFor = (projectId: string) => `bmus.view.${projectId}`;
 const EVT = "bmus:view";
 

--- a/hooks/use-url-filters.ts
+++ b/hooks/use-url-filters.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+import {
+  emptyFilters,
+  filtersFromSearchParams,
+  writeFiltersToSearchParams,
+  type Filters,
+} from "@/lib/filters";
+import { useUrlState } from "@/hooks/use-url-state";
+
+function sameFacets(a: Filters, b: Filters): boolean {
+  return (
+    a.status.join("\0") === b.status.join("\0") &&
+    a.type.join("\0") === b.type.join("\0") &&
+    a.priority.join("\0") === b.priority.join("\0") &&
+    a.origin.join("\0") === b.origin.join("\0") &&
+    a.labels.join("\0") === b.labels.join("\0")
+  );
+}
+
+/** Shared, URL-backed Board/List filter state. */
+export function useUrlFilters() {
+  const { searchParams, updateUrl } = useUrlState();
+  const filters = React.useMemo(
+    () => filtersFromSearchParams(searchParams),
+    [searchParams],
+  );
+  const showArchived = searchParams.get("archived") === "1";
+
+  const setFilters = React.useCallback(
+    (next: Filters) => {
+      const searchOnly =
+        sameFacets(filters, next) && filters.search !== next.search;
+      const mode = searchOnly && filters.search ? "replace" : "push";
+      updateUrl((params) => writeFiltersToSearchParams(params, next), mode);
+    },
+    [filters, updateUrl],
+  );
+
+  const setShowArchived = React.useCallback(
+    (show: boolean) => {
+      updateUrl((params) => {
+        if (show) params.set("archived", "1");
+        else params.delete("archived");
+      });
+    },
+    [updateUrl],
+  );
+
+  const clearFilters = React.useCallback(() => {
+    updateUrl((params) => {
+      writeFiltersToSearchParams(params, emptyFilters);
+      params.delete("archived");
+    });
+  }, [updateUrl]);
+
+  return { filters, setFilters, showArchived, setShowArchived, clearFilters };
+}

--- a/hooks/use-url-state.ts
+++ b/hooks/use-url-state.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+import { useSearchParams } from "next/navigation";
+
+export type UrlHistoryMode = "push" | "replace";
+export type UrlParamsUpdater = (params: URLSearchParams) => void;
+export type UrlUpdater = (url: URL) => void;
+
+/**
+ * Read and update view state in the current URL without causing a page reload.
+ * Native history calls are supported by the Next.js App Router and update every
+ * useSearchParams subscriber, including in response to back/forward navigation.
+ */
+export function useUrlState() {
+  const searchParams = useSearchParams();
+
+  const updateLocation = React.useCallback(
+    (update: UrlUpdater, mode: UrlHistoryMode = "push") => {
+      let url: URL;
+      try {
+        url = new URL(window.location.href);
+      } catch {
+        return;
+      }
+      update(url);
+
+      const next = `${url.pathname}${url.search}${url.hash}`;
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (next === current) return;
+
+      if (mode === "replace") window.history.replaceState(null, "", next);
+      else window.history.pushState(null, "", next);
+    },
+    [],
+  );
+
+  const updateUrl = React.useCallback(
+    (update: UrlParamsUpdater, mode: UrlHistoryMode = "push") => {
+      updateLocation((url) => update(url.searchParams), mode);
+    },
+    [updateLocation],
+  );
+
+  return { searchParams, updateLocation, updateUrl };
+}

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -24,6 +24,53 @@ export const emptyFilters: Filters = {
   search: "",
 };
 
+const FILTER_PARAMS = [
+  "status",
+  "type",
+  "priority",
+  "origin",
+  "label",
+  "q",
+] as const;
+
+type SearchParamsReader = Pick<URLSearchParams, "get" | "getAll">;
+
+function distinctValues(params: SearchParamsReader, name: string): string[] {
+  return [...new Set(params.getAll(name).filter(Boolean))];
+}
+
+/** Parse the shared Board/List filters from bookmarkable query parameters. */
+export function filtersFromSearchParams(params: SearchParamsReader): Filters {
+  return {
+    status: distinctValues(params, "status"),
+    type: distinctValues(params, "type"),
+    priority: distinctValues(params, "priority")
+      .map(Number)
+      .filter(
+        (priority) =>
+          Number.isInteger(priority) && priority >= 0 && priority <= 4,
+      ),
+    origin: distinctValues(params, "origin"),
+    labels: distinctValues(params, "label"),
+    search: params.get("q") ?? "",
+  };
+}
+
+/** Replace only filter-related parameters, preserving view and issue state. */
+export function writeFiltersToSearchParams(
+  params: URLSearchParams,
+  filters: Filters,
+): void {
+  for (const name of FILTER_PARAMS) params.delete(name);
+  for (const status of filters.status) params.append("status", status);
+  for (const type of filters.type) params.append("type", type);
+  for (const priority of filters.priority)
+    params.append("priority", String(priority));
+  for (const origin of filters.origin) params.append("origin", origin);
+  for (const label of filters.labels) params.append("label", label);
+  if (filters.search) params.set("q", filters.search);
+}
+
 /**
  * `archived` is state, not a tag — it has its own dedicated toggle in the
  * FilterBar and the views hide on it — so it never appears as a label facet

--- a/lib/keyboard-shortcuts.ts
+++ b/lib/keyboard-shortcuts.ts
@@ -1,0 +1,77 @@
+import type { View } from "@/components/app-context";
+
+export interface KeyboardShortcut {
+  keys: string[];
+  label: string;
+  sequence?: boolean;
+}
+
+export interface KeyboardShortcutGroup {
+  topic: string;
+  shortcuts: KeyboardShortcut[];
+}
+
+export const VIEW_KEY_BINDINGS: Record<string, View> = {
+  b: "board",
+  l: "list",
+  e: "epics",
+  g: "graph",
+  i: "insights",
+  a: "activity",
+  y: "needsyou",
+  h: "achievements",
+  p: "publish",
+  s: "settings",
+};
+
+export const KEYBOARD_SHORTCUT_GROUPS: KeyboardShortcutGroup[] = [
+  {
+    topic: "Global",
+    shortcuts: [
+      { keys: ["?"], label: "Show keyboard shortcuts" },
+      { keys: ["⌘/Ctrl", "K"], label: "Open the command palette" },
+      { keys: ["/"], label: "Focus search" },
+      { keys: ["N"], label: "Create an issue" },
+      { keys: ["T"], label: "Toggle light / dark theme" },
+      { keys: ["Esc"], label: "Close the active drawer or dialog" },
+    ],
+  },
+  {
+    topic: "Issues",
+    shortcuts: [
+      { keys: ["J"], label: "Select next visible issue" },
+      { keys: ["K"], label: "Select previous visible issue" },
+      { keys: ["H"], label: "Select issue to the left" },
+      { keys: ["L"], label: "Select issue to the right" },
+      { keys: ["Enter"], label: "Open selected issue" },
+      { keys: ["O"], label: "Open selected issue" },
+      { keys: ["E"], label: "Edit selected issue" },
+      { keys: ["C"], label: "Close selected issue with optional reason" },
+      { keys: ["S"], label: "Set selected issue status" },
+      { keys: ["P"], label: "Set selected issue priority" },
+    ],
+  },
+  {
+    topic: "Views",
+    shortcuts: [
+      { keys: ["G", "B"], label: "Board", sequence: true },
+      { keys: ["G", "L"], label: "List", sequence: true },
+      { keys: ["G", "E"], label: "Epics", sequence: true },
+      { keys: ["G", "G"], label: "Graph", sequence: true },
+      { keys: ["G", "I"], label: "Insights", sequence: true },
+      { keys: ["G", "A"], label: "Activity", sequence: true },
+      { keys: ["G", "Y"], label: "Needs You", sequence: true },
+      { keys: ["G", "H"], label: "Achievements", sequence: true },
+      { keys: ["G", "P"], label: "Publish", sequence: true },
+      { keys: ["G", "S"], label: "Settings", sequence: true },
+    ],
+  },
+  {
+    topic: "Repositories",
+    shortcuts: [
+      { keys: ["G", "R"], label: "Choose a repository", sequence: true },
+      { keys: ["G", "["], label: "Previous repository", sequence: true },
+      { keys: ["G", "]"], label: "Next repository", sequence: true },
+    ],
+  },
+];

--- a/lib/views.ts
+++ b/lib/views.ts
@@ -1,0 +1,20 @@
+export const VIEWS = [
+  "board",
+  "list",
+  "epics",
+  "graph",
+  "insights",
+  "activity",
+  "needsyou",
+  "achievements",
+  "publish",
+  "settings",
+] as const;
+
+export type View = (typeof VIEWS)[number];
+
+export function isView(value: string | null | undefined): value is View {
+  return (
+    typeof value === "string" && (VIEWS as readonly string[]).includes(value)
+  );
+}


### PR DESCRIPTION
## Summary

This is a relatively large navigation and state-management change, so I want to present it for discussion rather than assume the approach is ready to merge as-is.

It makes project views, selected issues, and relevant Board/List filters bookmarkable. Direct links restore the same application state, while browser back and forward navigation move through view and issue-selection history.

I recognize that changing the URL structure and making it authoritative for UI state could be contentious. I’m very willing to incorporate feedback, rework the design, reduce the scope, or split this into smaller changes before it is considered for merging.

## Changes

- Add route-backed project views under `/p/[projectId]/[view]`.
- Normalize bare project URLs and the previous query-string view representation to the route-based form.
- Preserve the existing per-project last-view preference as the fallback for URLs without a valid view.
- Store the selected issue in the query string so direct links reopen its detail drawer.
- Push issue opening, closing, and drawer navigation into browser history.
- Restore view and issue state when navigating backward or forward.
- Store shared Board/List filters in the URL:
  - status
  - type
  - priority
  - origin
  - label
  - text search
  - archived visibility
- Store the Board’s Done-column time window in the URL.
- Avoid creating one history entry per search keystroke: the initial search change pushes an entry, while subsequent typing replaces it.
- Centralize URL parsing and updates in shared hooks while preserving unrelated query parameters.

## Testing

- Production build completed successfully.
- ESLint passed for all changed source files.
- Manually verified:
  - direct links to views and selected issues
  - Board and List filter persistence
  - view navigation
  - opening and closing issue details
  - drawer-internal issue navigation
  - browser back and forward restoration
  - normalization of legacy and incomplete URLs

## Notes

This PR changes a foundational part of the application’s navigation model and touches several existing components. Although legacy URLs are normalized, the new route structure and URL-authoritative state deserve careful review.

The implementation currently uses the native History API together with Next.js navigation state. I’m open to replacing that approach if a more idiomatic or maintainable routing design is preferred.

Automated browser coverage is not included yet. I’m happy to add it, split this into smaller PRs, or otherwise revise the implementation based on maintainer feedback.

## Summary by Sourcery

Make project navigation, issue selection, filters, and keyboard interactions persist through bookmarkable URLs and browser history.

New Features:
- Make project views, selected issues, Board/List filters, and the Board Done-column window addressable through URLs.
- Add keyboard navigation, issue actions, view switching, repository cycling, and a shortcut reference dialog.

Bug Fixes:
- Normalize bare, legacy, incomplete, and invalid project URLs while preserving per-project last-view fallbacks.
- Restore issue drawers, selections, view state, and drawer navigation correctly during browser back and forward navigation.
- Prevent search typing from creating a separate browser history entry for every keystroke.

Enhancements:
- Centralize URL state and filter parsing while preserving unrelated query parameters.
- Improve keyboard focus and selected-issue visibility across issue cards, rows, graph nodes, activity items, epics, and needs-you views.
- Share and expand keyboard shortcut documentation in Settings and an on-demand reference dialog.