### PR TITLE
Skip autoFocus on touch devices

### DIFF
--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -12,6 +12,7 @@ import { CopyableId } from "@/components/copyable-id";
 import { useApp } from "@/components/app-context";
 import { useImageDrop } from "@/hooks/use-image-drop";
 import { useResizableWidth } from "@/hooks/use-resizable-width";
+import { useIsTouchDevice } from "@/hooks/use-is-touch-device";
 import { DescriptionContent } from "@/components/description-content";
 import { MarkdownToolbar, applyTransform } from "@/components/markdown-toolbar";
 import { bold, italic, link } from "@/lib/markdown-edit";
@@ -154,6 +155,7 @@ function DrawerBody({
   const [addingGate, setAddingGate] = React.useState(false);
   const [gateReason, setGateReason] = React.useState("");
   const gateBead = isHumanGate(bead);
+  const isTouch = useIsTouchDevice();
 
   // Closing is the only moment a reason can be recorded — bd offers no way to
   // attach one afterwards — so picking "Closed" opens a skippable composer
@@ -701,7 +703,7 @@ function DrawerBody({
               (addingGate ? (
                 <div className="flex items-center gap-[7px] rounded-[9px] border border-border bg-[var(--surface)] p-[9px_11px]">
                   <input
-                    autoFocus
+                    autoFocus={!isTouch}
                     value={gateReason}
                     onChange={(e) => setGateReason(e.target.value)}
                     onKeyDown={(e) => {

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -9,6 +9,7 @@ import { Icon } from "@/components/icons";
 import { useApp, type View } from "@/components/app-context";
 import { useProjects } from "@/hooks/use-projects";
 import { useSetStatus, useUpdateBead } from "@/hooks/use-beads";
+import { useIsTouchDevice } from "@/hooks/use-is-touch-device";
 import { BEAD_STATUSES, type Bead } from "@/lib/schema";
 import { statusLabel, catColor, typeLabel } from "@/lib/beads-view";
 
@@ -75,6 +76,7 @@ function PaletteBody({ onView, close }: { onView: (v: View) => void; close: () =
   const update = useUpdateBead();
   const { data: projectsData } = useProjects();
   const projects = projectsData?.projects ?? [];
+  const isTouch = useIsTouchDevice();
 
   const [page, setPage] = React.useState<Page>("root");
   const [search, setSearch] = React.useState("");
@@ -125,7 +127,7 @@ function PaletteBody({ onView, close }: { onView: (v: View) => void; close: () =
           <Icon name="search" size={16} className="ml-1 text-[var(--text-3)]" />
         )}
         <Command.Input
-          autoFocus
+          autoFocus={!isTouch}
           value={search}
           onValueChange={setSearch}
           placeholder={

--- a/components/create-bead-modal.tsx
+++ b/components/create-bead-modal.tsx
@@ -13,6 +13,7 @@ import { useApp } from "@/components/app-context";
 import { useCreateBead, beadsKey } from "@/hooks/use-beads";
 import { useImageDrop } from "@/hooks/use-image-drop";
 import { useResizableWidth } from "@/hooks/use-resizable-width";
+import { useIsTouchDevice } from "@/hooks/use-is-touch-device";
 import { DescriptionContent, hasImageRef } from "@/components/description-content";
 import { api } from "@/lib/api-client";
 import { typeLabel } from "@/lib/beads-view";
@@ -89,6 +90,7 @@ function CreateForm({
   const { beads, meta, projectId } = useApp();
   const create = useCreateBead();
   const qc = useQueryClient();
+  const isTouch = useIsTouchDevice();
   const actor = meta?.humanActor ?? "you";
   const isDemo = meta?.kind === "demo";
 
@@ -269,7 +271,7 @@ function CreateForm({
         <label className="flex flex-col gap-[6px]">
           <span className={labelClass}>Title</span>
           <textarea
-            autoFocus
+            autoFocus={!isTouch}
             ref={autosize}
             rows={1}
             className={`${inputClass} h-auto min-h-[38px] resize-none overflow-hidden py-[9px] leading-[1.4]`}

--- a/hooks/use-is-touch-device.ts
+++ b/hooks/use-is-touch-device.ts
@@ -1,0 +1,21 @@
+"use client";
+import * as React from "react";
+
+const QUERY = "(hover: none) and (pointer: coarse)";
+
+/**
+ * True when the primary input has no hover and a coarse pointer (touch).
+ * Defaults to false until mounted so SSR/first-paint markup matches the
+ * client, then syncs — used to skip autoFocus on touch devices, where
+ * popping the keyboard immediately shoves the layout before the user has
+ * looked at the screen.
+ */
+export function useIsTouchDevice(): boolean {
+  const subscribe = React.useCallback((cb: () => void) => {
+    const mql = window.matchMedia(QUERY);
+    mql.addEventListener("change", cb);
+    return () => mql.removeEventListener("change", cb);
+  }, []);
+  const getSnapshot = React.useCallback(() => window.matchMedia(QUERY).matches, []);
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false);
+}


### PR DESCRIPTION
## Summary
Never autofocus a text input on a touch device — autofocusing pops the on-screen keyboard immediately, which on a phone shoves the layout up before the user has looked at the screen. Desktop/keyboard users still get instant focus, since this conditions autofocus on input modality rather than removing it.

## Changes
- New `hooks/use-is-touch-device.ts`: `useIsTouchDevice()` hook using `window.matchMedia("(hover: none) and (pointer: coarse)")`, SSR-safe via `useSyncExternalStore` (defaults to `false` until mounted).
- Three call sites now pass `autoFocus={!isTouch}` instead of unconditional `autoFocus`:
  - `components/command-palette.tsx` — command palette search input
  - `components/create-bead-modal.tsx` — create-issue modal "Title" textarea
  - `components/bead-detail-drawer.tsx` — inline add-dependency-gate reason input

Scoped to input-modality only (no screen-width/`isMobile` breakpoint logic added) — that axis is owned by the separate in-flight mobile-board PR, which this branch does not touch.

## Validation
- `tsc --noEmit` — clean
- `npm run lint` (eslint) — clean
- `npm run build` — clean
- Dev server smoke test — page serves 200, no hydration errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Conditionally skip input autofocus on touch devices to avoid immediately popping the on-screen keyboard while preserving autofocus for keyboard users.

New Features:
- Introduce a reusable useIsTouchDevice hook to detect coarse, non-hover primary input devices via matchMedia.

Enhancements:
- Update command palette, create-bead modal, and bead detail drawer inputs to only autofocus when the device is not touch-based.