### PR TITLE
feat(filters): assignee facet on Board and List

### DIFF
--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -16,7 +16,7 @@ import { useOrder, useSetOrder } from "@/hooks/use-order";
 import { useBoardPrefs } from "@/hooks/use-board-prefs";
 import { isBlocked, childrenCountMap } from "@/lib/beads-view";
 import { FilterBar } from "@/components/filter-bar";
-import { matchesFilters, emptyFilters, labelOptionsFrom, type Filters } from "@/lib/filters";
+import { matchesFilters, emptyFilters, labelOptionsFrom, assigneeOptionsFrom, type Filters } from "@/lib/filters";
 import { BOARD_COLUMNS as COLUMNS, sortByOrder as sortCards } from "@/lib/board-columns";
 import { Column } from "./column";
 import type { Bead } from "@/lib/schema";
@@ -33,6 +33,7 @@ export function Board() {
   // Derived from ALL beads (not the filtered set) so selecting one label
   // doesn't make the remaining options vanish from the dropdown.
   const labelOptions = React.useMemo(() => labelOptionsFrom(beads), [beads]);
+  const assigneeOptions = React.useMemo(() => assigneeOptionsFrom(beads), [beads]);
   // One pass over all beads, not childrenOf() per card — that would be O(n^2)
   // on a large board.
   const childCounts = React.useMemo(() => childrenCountMap(beads), [beads]);
@@ -136,6 +137,7 @@ export function Board() {
           filters={filters}
           onChange={setFilters}
           labelOptions={labelOptions}
+          assigneeOptions={assigneeOptions}
           showArchived={showArchived}
           onShowArchived={setShowArchived}
         />

--- a/components/filter-bar.tsx
+++ b/components/filter-bar.tsx
@@ -8,21 +8,23 @@ import { type Filters, emptyFilters, toggleStr, toggleNum } from "@/lib/filters"
 
 /**
  * Search + multi-select facet filters, shared by the Board and List views so
- * both expose the same controls (status, type, priority, labels, origin) +
- * archived. Purely presentational: `labelOptions` is the one data-derived facet
- * (the rest come from static enums) and is passed in rather than read from
- * context here.
+ * both expose the same controls (status, type, priority, labels, assignee,
+ * origin) + archived. Purely presentational: `labelOptions` and
+ * `assigneeOptions` are the data-derived facets (the rest come from static
+ * enums) and are passed in rather than read from context here.
  */
 export function FilterBar({
   filters,
   onChange,
   labelOptions,
+  assigneeOptions,
   showArchived,
   onShowArchived,
 }: {
   filters: Filters;
   onChange: (f: Filters) => void;
   labelOptions: FilterOption[];
+  assigneeOptions: FilterOption[];
   showArchived: boolean;
   onShowArchived: (v: boolean) => void;
 }) {
@@ -36,6 +38,7 @@ export function FilterBar({
     (filters.priority.length ? 1 : 0) +
     (filters.origin.length ? 1 : 0) +
     (filters.labels.length ? 1 : 0) +
+    (filters.assignee.length ? 1 : 0) +
     (filters.search.trim() ? 1 : 0) +
     (showArchived ? 1 : 0);
   const clearAll = () => {
@@ -85,6 +88,15 @@ export function FilterBar({
             selected={filters.labels}
             onToggle={(v) => set({ labels: toggleStr(filters.labels, v) })}
             onClear={() => set({ labels: [] })}
+          />
+        )}
+        {assigneeOptions.length > 0 && (
+          <MultiSelectFilter
+            label="Assignee"
+            options={assigneeOptions}
+            selected={filters.assignee}
+            onToggle={(v) => set({ assignee: toggleStr(filters.assignee, v) })}
+            onClear={() => set({ assignee: [] })}
           />
         )}
         <MultiSelectFilter

--- a/components/list-view.tsx
+++ b/components/list-view.tsx
@@ -22,7 +22,7 @@ import { CopyableId } from "@/components/copyable-id";
 import { FilterBar } from "@/components/filter-bar";
 import { useOrder, useSetOrder } from "@/hooks/use-order";
 import { useSetStatus } from "@/hooks/use-beads";
-import { matchesFilters, emptyFilters, labelOptionsFrom, type Filters } from "@/lib/filters";
+import { matchesFilters, emptyFilters, labelOptionsFrom, assigneeOptionsFrom, type Filters } from "@/lib/filters";
 import { BOARD_COLUMNS, COLUMN_ORDER, colOf } from "@/lib/board-columns";
 import { beadOrigin, originTitle } from "@/lib/attribution";
 import {
@@ -65,6 +65,7 @@ export function ListView() {
   // Derived from ALL beads (not the filtered set) so selecting one label
   // doesn't make the remaining options vanish from the dropdown.
   const labelOptions = React.useMemo(() => labelOptionsFrom(beads), [beads]);
+  const assigneeOptions = React.useMemo(() => assigneeOptionsFrom(beads), [beads]);
   // One pass, not childrenOf() per row (that would be O(n^2)).
   const childCounts = React.useMemo(() => childrenCountMap(beads), [beads]);
 
@@ -159,6 +160,7 @@ export function ListView() {
           filters={filters}
           onChange={setFilters}
           labelOptions={labelOptions}
+          assigneeOptions={assigneeOptions}
           showArchived={showArchived}
           onShowArchived={setShowArchived}
         />

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -12,6 +12,7 @@ export interface Filters {
   priority: number[];
   origin: string[];
   labels: string[];
+  assignee: string[];
   search: string;
 }
 
@@ -21,8 +22,37 @@ export const emptyFilters: Filters = {
   priority: [],
   origin: [],
   labels: [],
+  assignee: [],
   search: "",
 };
+
+/**
+ * Sentinel facet value for beads with no assignee, so "Unassigned" is
+ * selectable alongside real assignees in the same multi-select.
+ */
+export const UNASSIGNED = "__unassigned__";
+
+/** A bead's assignee normalized to a facet value (empty/blank → UNASSIGNED). */
+export function beadAssignee(b: Bead): string {
+  return b.assignee?.trim() || UNASSIGNED;
+}
+
+/**
+ * The distinct assignees in use across a bead set, sorted, as filter options —
+ * with "Unassigned" first when any bead lacks one. Callers pass ALL beads (not
+ * the filtered set), same as labelOptionsFrom.
+ */
+export function assigneeOptionsFrom(beads: Bead[]): { value: string; label: string }[] {
+  const s = new Set<string>();
+  let hasUnassigned = false;
+  for (const b of beads) {
+    const a = beadAssignee(b);
+    if (a === UNASSIGNED) hasUnassigned = true;
+    else s.add(a);
+  }
+  const opts = [...s].sort().map((a) => ({ value: a, label: a }));
+  return hasUnassigned ? [{ value: UNASSIGNED, label: "Unassigned" }, ...opts] : opts;
+}
 
 /**
  * `archived` is state, not a tag — it has its own dedicated toggle in the
@@ -44,7 +74,14 @@ export function labelOptionsFrom(beads: Bead[]): { value: string; label: string 
 
 /** Count of active facet selections (excludes free-text search). */
 export function activeFilterCount(f: Filters): number {
-  return f.status.length + f.type.length + f.priority.length + f.origin.length + f.labels.length;
+  return (
+    f.status.length +
+    f.type.length +
+    f.priority.length +
+    f.origin.length +
+    f.labels.length +
+    f.assignee.length
+  );
 }
 
 export function matchesFilters(b: Bead, f: Filters, humanAllowlist: string[]): boolean {
@@ -52,6 +89,7 @@ export function matchesFilters(b: Bead, f: Filters, humanAllowlist: string[]): b
   if (f.type.length && !f.type.includes(b.issue_type)) return false;
   if (f.priority.length && !f.priority.includes(b.priority)) return false;
   if (f.origin.length && !f.origin.includes(beadOrigin(b, humanAllowlist))) return false;
+  if (f.assignee.length && !f.assignee.includes(beadAssignee(b))) return false;
   // OR within the facet, like every other facet above; AND across facets.
   if (f.labels.length && !f.labels.some((l) => (b.labels ?? []).includes(l))) return false;
   const q = f.search.trim().toLowerCase();


### PR DESCRIPTION
Adds an **Assignee** multi-select facet to the shared FilterBar, next to Labels — we run boards where most beads are unassigned and a handful of people share the rest, and filtering by assignee was the one facet we kept reaching for.

- Same OR-within-facet / AND-across-facets semantics as the existing facets.
- Beads with a blank assignee are selectable via an **Unassigned** option (sentinel value `__unassigned__`, listed first).
- Options are derived from ALL beads (like `labelOptionsFrom`) so making a selection doesn't erase the remaining options.
- Wired through both FilterBar consumers (Board + List); `activeFilterCount` and the clear-all counter include the new facet.

No new deps; `tsc` and `next build` clean.

## Summary by Sourcery

Add an assignee facet to the shared FilterBar and wire it through both Board and List views so beads can be filtered by assignee, including an explicit Unassigned option.

New Features:
- Introduce an assignee multi-select facet alongside existing filters in the shared FilterBar.
- Expose assignee filter controls in both Board and List views, derived from assignee usage across all beads.

Enhancements:
- Extend filter counting and matching logic to include assignee selections, keeping active filter indicators and clear-all behavior consistent.