### PR TITLE
feat(permalink): direct link to a bead at /p/<project>/<bead>

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ for AI agents.
 - **Dependencies & graph** — view/add/remove typed dependencies in the detail
   drawer, plus an interactive React Flow dependency graph (drag node→node to link).
 - **Comments** — author-stamped comment threads with a composer on every bead.
+- **Permalinks** — every bead is addressable at `/p/<project>/<bead>`, opening
+  with its drawer showing; the address bar tracks the open bead and the drawer
+  header has a copy-link button.
 - **Archive & delete** — archive (reversible `bd close` + `archived` label) or
   delete (`bd delete`, behind a confirm).
 - **Human-vs-agent attribution** — every bead and comment shows 👤 (human) or 🤖

--- a/app/p/[projectId]/[beadId]/page.tsx
+++ b/app/p/[projectId]/[beadId]/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { AppShell } from "@/components/app-shell";
+import { projectTitle } from "@/lib/app-title";
+import { getProject } from "@/lib/config";
+
+/**
+ * Permalink to a single bead: /p/<projectId>/<beadId> opens the project with
+ * that bead's detail drawer already open. The AppShell keeps the address bar
+ * in sync as the drawer opens/closes, so this URL is always shareable.
+ */
+type Props = {
+  params: Promise<{ projectId: string; beadId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { projectId, beadId } = await params;
+  const project = getProject(projectId);
+
+  return project ? { title: projectTitle(`${beadId} · ${project.name}`) } : {};
+}
+
+export default async function BeadPermalinkPage({ params }: Props) {
+  const { projectId, beadId } = await params;
+  return <AppShell projectId={projectId} initialBeadId={beadId} />;
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 import * as React from "react";
+import { toast } from "sonner";
 import { type BeadType } from "@/lib/schema";
 import Link from "next/link";
 import { useBeads } from "@/hooks/use-beads";
@@ -24,14 +25,23 @@ import { CreateBeadModal } from "@/components/create-bead-modal";
 import { CommandPalette } from "@/components/command-palette";
 import { NotificationWatcher } from "@/components/notification-watcher";
 
-export function AppShell({ projectId }: { projectId: string }) {
+export function AppShell({
+  projectId,
+  initialBeadId,
+}: {
+  projectId: string;
+  /** Deep link (/p/<project>/<bead>): open with this bead's drawer showing. */
+  initialBeadId?: string;
+}) {
   const [view, setView] = useLastView(projectId);
   const { toggle: toggleTheme } = useTheme();
   // Drawer navigation TRAIL, not a single id: clicking a subtask from its
   // parent used to replace the drawer outright, leaving no way back (GH #15).
   // The visible bead is the last entry.
-  const [openStack, setOpenStack] = React.useState<string[]>([]);
-  const openId = openStack.length ? openStack[openStack.length - 1] : null;
+  const [openStack, setOpenStack] = React.useState<string[]>(
+    initialBeadId ? [initialBeadId] : [],
+  );
+  const rawOpenId = openStack.length ? openStack[openStack.length - 1] : null;
   const [palette, setPalette] = React.useState(false);
   const [create, setCreate] = React.useState<{
     open: boolean;
@@ -45,6 +55,15 @@ export function AppShell({ projectId }: { projectId: string }) {
   const { live } = useBeadsStream(projectId);
   const beads = React.useMemo(() => data?.beads ?? [], [data]);
   const index = React.useMemo(() => makeIndex(beads), [beads]);
+
+  // An id the loaded project doesn't have (deep-link typo, deleted bead) is
+  // DERIVED to null rather than cleared with setState — the codebase stays off
+  // setState-in-effect (see theme-provider.tsx) — so the drawer closes while
+  // the trail stays put; any interaction (Esc, opening a bead) resets it.
+  // Until data arrives every id is taken at its word, which keeps a deep link's
+  // URL stable through the initial load.
+  const loaded = !isLoading && !error && !!data;
+  const openId = rawOpenId && loaded && !index.has(rawOpenId) ? null : rawOpenId;
 
   // RESET. Every caller outside the drawer (board, list, epics, activity,
   // needs-you, palette, assist panel) means "start here", not "continue a trail".
@@ -70,6 +89,37 @@ export function AppShell({ projectId }: { projectId: string }) {
       return next;
     });
   }, [index]);
+  // Keep the address bar a permalink: /p/<project>/<bead> while a drawer is
+  // open, /p/<project> otherwise, so the URL is always shareable. Native
+  // history.replaceState (which the app router syncs with, per the shallow-
+  // routing guide) rather than router.replace: drawer browsing shouldn't
+  // re-run the server route or grow the back stack.
+  React.useEffect(() => {
+    const base = `/p/${encodeURIComponent(projectId)}`;
+    const target = openId ? `${base}/${encodeURIComponent(openId)}` : base;
+    if (window.location.pathname !== target) {
+      window.history.replaceState(
+        window.history.state,
+        "",
+        target + window.location.search + window.location.hash,
+      );
+    }
+  }, [projectId, openId]);
+
+  // A missing id would otherwise just be a drawer that silently never opens;
+  // say so once the data is in. The ref dedupes across refetches — `index` is
+  // rebuilt every poll, and a still-missing id must not re-toast each time.
+  const missingToasted = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    if (!loaded || !rawOpenId || index.has(rawOpenId)) {
+      missingToasted.current = null;
+      return;
+    }
+    if (missingToasted.current === rawOpenId) return;
+    missingToasted.current = rawOpenId;
+    toast.error(`Bead ${rawOpenId} not found in this project`);
+  }, [loaded, rawOpenId, index]);
+
   // Options object rather than positional args so future presets (assignee,
   // priority) can be added without churning every call site again.
   const openCreate = React.useCallback(

--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -1,5 +1,6 @@
 "use client";
 import * as React from "react";
+import { toast } from "sonner";
 import {
   Sheet,
   SheetContent,
@@ -147,6 +148,20 @@ function DrawerBody({
   const del = useDeleteBead();
   const createGate = useCreateGate();
 
+  // Same clipboard handling as CopyableId, but for the bead's permalink URL —
+  // the /p/<project>/<bead> route this drawer is addressable at.
+  const copyLink = () => {
+    const url = `${window.location.origin}/p/${encodeURIComponent(projectId)}/${encodeURIComponent(bead.id)}`;
+    if (!navigator.clipboard) {
+      toast.error("Clipboard unavailable in this context");
+      return;
+    }
+    navigator.clipboard.writeText(url).then(
+      () => toast.success(`Copied link to ${bead.id}`),
+      () => toast.error("Couldn’t copy to clipboard"),
+    );
+  };
+
   const [draft, setDraft] = React.useState("");
   const [addingDep, setAddingDep] = React.useState(false);
   const [depTarget, setDepTarget] = React.useState("");
@@ -264,6 +279,9 @@ function DrawerBody({
         <CopyableId id={bead.id} className="font-mono text-[13px] text-[var(--text-2)]" />
         <StatusChip status={bead.status} />
         <span className="flex-1" />
+        <IconBtn title="Copy link" onClick={copyLink}>
+          <Icon name="link" size={15} />
+        </IconBtn>
         <IconBtn
           title={editing ? "Stop editing" : "Edit title & description"}
           onClick={editing ? cancelEdit : startEdit}


### PR DESCRIPTION
A bead has no shareable address today — the detail drawer is client-only state, so pointing a teammate (or an agent's report) at a specific ticket means "open the board and search for the id".

## What

- **`/p/<projectId>/<beadId>`** — new route that renders the project with that bead's drawer already open. SSR metadata titles the page `<beadId> · <project>`, so shared links preview meaningfully.
- **The address bar tracks the drawer**: opening a bead rewrites the URL to its permalink and closing restores `/p/<projectId>`, via native `window.history.replaceState`, which the app router syncs with (per the shallow-routing guide). Drawer browsing never re-runs the server route or grows the back stack, and drawer-internal trail navigation (#15) keeps working — the URL simply follows the visible bead.
- **Copy-link button** in the drawer header, next to the existing copy-id affordance, mirroring `CopyableId`'s clipboard handling.
- **Unknown id** (typo, deleted bead): a not-found toast once data loads, and the URL resets to the project. The missing id is *derived* to a closed drawer instead of cleared with setState-in-effect, staying inside the React Compiler lint the repo already honors.

## Verified

- `next build` + `eslint` clean.
- Playwright against the built app: deep link opens the drawer with the URL stable through load; Esc closes and reverts the URL; opening a bead from the board rewrites the URL to its permalink; unknown id toasts, keeps the drawer closed, and resets the URL; copy-link button present.

Independent of #36 — based on `main`.

## Summary by Sourcery

Add bead permalinks under project routes so individual beads can be deep-linked and the drawer state is reflected in the URL.

New Features:
- Introduce a /p/<projectId>/<beadId> page that opens the project with the specified bead’s detail drawer initially visible and sets SSR metadata to include the bead id and project name.
- Add a copy-link button in the bead detail drawer header to copy the bead’s permalink URL to the clipboard.

Enhancements:
- Make the app shell track the currently open bead and keep the browser URL in sync, using permalinks while the drawer is open and reverting to the project URL when it is closed.
- Handle missing or invalid bead ids by deriving them to a closed drawer and showing a one-time toast error once project data is loaded.

Documentation:
- Update the README to document bead permalinks, including the addressable /p/<project>/<bead> route, URL tracking behavior, and the drawer copy-link control.