### PR TITLE
feat(drawer): make a bead URL-addressable via ?bead=<ID>

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -30,7 +30,18 @@ export function AppShell({ projectId }: { projectId: string }) {
   // Drawer navigation TRAIL, not a single id: clicking a subtask from its
   // parent used to replace the drawer outright, leaving no way back (GH #15).
   // The visible bead is the last entry.
-  const [openStack, setOpenStack] = React.useState<string[]>([]);
+  //
+  // Seeded from `?bead=<ID>` so a bead is URL-addressable (see the sync effect
+  // below). Read during render rather than in a mount effect: the repo's React
+  // Compiler lint forbids setState-in-effect, and the seed is safe to hydrate
+  // with because the drawer's open state also depends on the bead being present
+  // in `index` — react-query has no SSR prefetch here, so server and first
+  // client render both see an empty index and render the drawer closed.
+  const [openStack, setOpenStack] = React.useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    const seed = new URLSearchParams(window.location.search).get("bead");
+    return seed ? [seed] : [];
+  });
   const openId = openStack.length ? openStack[openStack.length - 1] : null;
   const [palette, setPalette] = React.useState(false);
   const [create, setCreate] = React.useState<{
@@ -61,6 +72,25 @@ export function AppShell({ projectId }: { projectId: string }) {
     [],
   );
   const closeDetail = React.useCallback(() => setOpenStack([]), []);
+
+  // URL-ADDRESSABLE BEAD. `/p/<projectId>?bead=<ID>` opens that bead, and the
+  // drawer keeps the URL in step, so a single bead is linkable — shareable, and
+  // reachable from outside the app (a terminal can turn a bead id into a link).
+  //
+  // Plain History API rather than useSearchParams/router.replace: the URL is
+  // only a bookmark here, never a data source. replaceState keeps the drawer
+  // out of the back-stack (the drawer has its own Back for the trail) and skips
+  // both the Suspense boundary useSearchParams would demand of every page
+  // rendering AppShell and a server round-trip on each open.
+  React.useEffect(() => {
+    const url = new URL(window.location.href);
+    if (openId) url.searchParams.set("bead", openId);
+    else url.searchParams.delete("bead");
+    const next = `${url.pathname}${url.search}${url.hash}`;
+    const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    if (next !== current) window.history.replaceState(window.history.state, "", next);
+  }, [openId]);
+
   // POP. Skips entries whose bead has since been deleted/archived away, so back
   // can never land on an empty drawer; if nothing valid remains, it closes.
   const backDetail = React.useCallback(() => {


### PR DESCRIPTION
## Problem

The drawer's open bead lives only in React state (`openStack` in `app-shell.tsx`), so no link can target a single bead — the deepest addressable URL is the project board `/p/<projectId>`. That blocks sharing a bead with someone, and blocks anything outside the app (a terminal, an editor) from turning a bead id into a working link.

## Change

Bind the trail's head to a `bead` search param in both directions: seed `openStack` from `?bead=` on first render, and keep the param in step as the drawer opens, navigates and closes. `/p/<projectId>?bead=<ID>` now opens that bead.

One file, +31/−1.

## Notes on the approach

- **Plain History API, not `useSearchParams` / `router.replace`.** The URL is a bookmark here, never a data source. `replaceState` keeps the drawer out of the back-stack (it already has its own Back for the subtask trail from #15) and avoids both the Suspense boundary `useSearchParams` would demand of every page rendering `AppShell`, and a server round-trip on each open.
- **The seed is a lazy `useState` initializer, not a mount effect** — the React Compiler lint (`react-hooks/set-state-in-effect`) rejects setState-in-effect. This is safe to hydrate with: the drawer's open state also requires the bead to be present in `index`, and react-query has no SSR prefetch here, so the server render and the first client render both see an empty index and render the drawer closed.
- **The sync effect has an equality guard**, which makes the mount pass a no-op — so it needs no "skip first render" ref.
- **Unknown ids are inert.** The drawer stays closed and the app keeps working, same as a bead that has since been archived away.

## Verification

`npx tsc --noEmit` and `eslint` clean; `next build` passes.

Also driven end-to-end with Playwright against a real 232-bead project:

- deep link opens the drawer on the right bead
- Escape closes it and drops the param
- opening a card from the board writes the id actually being shown
- a bogus `?bead=` neither crashes the app nor opens the drawer
- unrelated query params survive the sync in both directions

Happy to fold that script into the repo if you'd like an e2e harness — I left it out since there's no test infra to hang it on yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make individual beads in the drawer directly addressable via a `?bead=<ID>` query parameter on project URLs.

New Features:
- Allow `/p/<projectId>?bead=<ID>` URLs to open the drawer focused on the specified bead.

Enhancements:
- Initialize and keep the drawer’s open bead state in sync with the `bead` query parameter without affecting browser back-stack behavior.