### PR TITLE
feat: dependency neighborhood — downstream in drawer, spotlight in graph

### DIFF
--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -223,6 +223,17 @@ function DrawerBody({
   // epicProgress is parent-agnostic despite the name (worth renaming later).
   const kidProgress = epicProgress(bead.id, beads);
   const deps = (bead.dependencies ?? []).filter((d) => d.type !== "parent-child");
+  // The reverse direction: beads whose dependency edges point AT this one —
+  // i.e. what closing this bead unblocks. The edge lives on the other bead,
+  // so this is the only place downstream impact is visible.
+  const dependents = beads
+    .map((b) => ({
+      bead: b,
+      dep: (b.dependencies ?? []).find(
+        (d) => d.depends_on_id === bead.id && d.type !== "parent-child",
+      ),
+    }))
+    .filter((x): x is { bead: Bead; dep: NonNullable<typeof x.dep> } => !!x.dep);
   const notes = bead.notes?.trim() ?? "";
   const design = bead.design?.trim() ?? "";
   const acceptance = bead.acceptance_criteria?.trim() ?? "";
@@ -740,6 +751,49 @@ function DrawerBody({
               ))}
           </div>
         </Section>
+
+        {/* Downstream: beads waiting on this one. The edge lives on the other
+            bead, so it is read-only here — click through to manage it. */}
+        {dependents.length > 0 && (
+          <Section>
+            <Header icon="milestone" label="Blocks" count={dependents.length} />
+            <div className="flex flex-col gap-[7px]">
+              {dependents.map(({ bead: t, dep }) => {
+                const blocking = BLOCKING_DEP_TYPES.includes(dep.type as DepType);
+                const c = blocking ? "#ef4444" : "var(--text-2)";
+                return (
+                  <button
+                    key={t.id}
+                    onClick={() => pushDetail(t.id)}
+                    className="flex items-center gap-[9px] rounded-[9px] border border-border bg-[var(--surface)] p-[9px_11px] text-left hover:border-[var(--border-strong)]"
+                  >
+                    <span
+                      className="flex-shrink-0 rounded-[5px] px-[7px] py-[2px] font-mono text-[10px] font-semibold"
+                      style={{
+                        color: c,
+                        background: blocking ? "#ef444418" : "var(--surface-2)",
+                        border: `1px solid ${blocking ? "#ef444433" : "var(--border)"}`,
+                      }}
+                    >
+                      {blocking ? "blocked by this" : dep.type}
+                    </span>
+                    <span className="flex-shrink-0 font-mono text-[11px] text-[var(--text-3)]">
+                      {t.id}
+                    </span>
+                    <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
+                      {t.title}
+                    </span>
+                    <span
+                      className="h-[7px] w-[7px] flex-shrink-0 rounded-full"
+                      style={{ background: catColor(t.status) }}
+                      title={statusLabel(t.status)}
+                    />
+                  </button>
+                );
+              })}
+            </div>
+          </Section>
+        )}
 
         {/* Subtasks — one level deep, deliberately not recursive. */}
         <Section>

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -148,6 +148,53 @@ export function GraphView() {
     return () => clearTimeout(t);
   }, [showClosed]);
 
+  // Clicking a node spotlights its dependency neighborhood: the transitive
+  // upstream chain (what it waits on) and downstream chain (what waits on it).
+  // Everything else dims. Clicking the pane clears it.
+  const [focusId, setFocusId] = React.useState<string | null>(null);
+  const focus = React.useMemo(() => {
+    if (!focusId) return null;
+    const up = new Set([focusId]);
+    const down = new Set([focusId]);
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const e of edges) {
+        if (up.has(e.source) && !up.has(e.target)) {
+          up.add(e.target);
+          grew = true;
+        }
+        if (down.has(e.target) && !down.has(e.source)) {
+          down.add(e.source);
+          grew = true;
+        }
+      }
+    }
+    return { all: new Set([...up, ...down]), up: up.size - 1, down: down.size - 1 };
+  }, [focusId, edges]);
+
+  const shownNodes = React.useMemo(() => {
+    if (!focus) return nodes;
+    return nodes.map((n) => ({
+      ...n,
+      style: {
+        ...n.style,
+        opacity: focus.all.has(n.id) ? 1 : 0.12,
+        outline: n.id === focusId ? "2.5px solid var(--brand)" : undefined,
+        outlineOffset: n.id === focusId ? 3 : undefined,
+        borderRadius: 11,
+      },
+    }));
+  }, [nodes, focus, focusId]);
+
+  const shownEdges = React.useMemo(() => {
+    if (!focus) return edges;
+    return edges.map((e) => {
+      const lit = focus.all.has(e.source) && focus.all.has(e.target);
+      return { ...e, style: { ...e.style, opacity: lit ? 1 : 0.05 }, animated: lit && e.animated };
+    });
+  }, [edges, focus]);
+
   const onConnect = React.useCallback(
     (c: Connection) => {
       if (c.source && c.target && c.source !== c.target) {
@@ -167,6 +214,20 @@ export function GraphView() {
             (cycle-checked by bd)
           </span>
         </div>
+        {focus && focusId && (
+          <button
+            onClick={() => setFocusId(null)}
+            title="Clear the neighborhood spotlight"
+            className="flex h-9 flex-shrink-0 items-center gap-[7px] rounded-[9px] px-[12px] text-[12.5px] font-[550] text-[var(--brand)]"
+            style={{ background: "var(--brand-weak)" }}
+          >
+            <span className="font-mono">{focusId}</span>
+            <span className="text-[11.5px] opacity-80">
+              ↑{focus.up} · ↓{focus.down}
+            </span>
+            <Icon name="x" size={13} />
+          </button>
+        )}
         <label className="flex h-9 flex-shrink-0 cursor-pointer items-center gap-[7px] rounded-[9px] border border-border bg-[var(--surface-2)] px-[12px] text-[12.5px] font-[550] text-[var(--text-2)] hover:bg-[var(--surface-3)]">
           <input
             type="checkbox"
@@ -187,10 +248,12 @@ export function GraphView() {
       </header>
       <div className="relative min-h-0 flex-1">
         <ReactFlow
-          nodes={nodes}
-          edges={edges}
+          nodes={shownNodes}
+          edges={shownEdges}
           nodeTypes={nodeTypes}
           onConnect={onConnect}
+          onNodeClick={(_, n) => setFocusId(n.id)}
+          onPaneClick={() => setFocusId(null)}
           onInit={(inst) => {
             rf.current = inst;
           }}

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -53,18 +53,26 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
   );
 
   const nodes: Node[] = [];
+  const seen = new Set<string>();
+  // An epic can be both a column head and another epic's child; React Flow
+  // rejects duplicate node ids, so the first placement wins.
+  const push = (n: Node) => {
+    if (seen.has(n.id)) return;
+    seen.add(n.id);
+    nodes.push(n);
+  };
   const COL = 230;
   const ROW = 116;
 
   epics.forEach((e, ci) => {
-    nodes.push({
+    push({
       id: e.id,
       type: "bead",
       position: { x: ci * COL, y: 0 },
       data: { bead: e, onOpen },
     });
     childrenOf(e.id, beads).forEach((k, ri) => {
-      nodes.push({
+      push({
         id: k.id,
         type: "bead",
         position: { x: ci * COL, y: (ri + 1) * ROW },
@@ -73,12 +81,15 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
     });
   });
 
+  // Wrap the loose beads into a grid instead of one endless column, so the
+  // fitted view stays near screen aspect ratio.
   const looseCol = epics.length;
+  const WRAP = Math.max(6, Math.ceil(Math.sqrt(loose.length * 2)));
   loose.forEach((b, ri) => {
-    nodes.push({
+    push({
       id: b.id,
       type: "bead",
-      position: { x: looseCol * COL, y: ri * ROW },
+      position: { x: (looseCol + Math.floor(ri / WRAP)) * COL, y: (ri % WRAP) * ROW },
       data: { bead: b, onOpen },
     });
   });
@@ -114,10 +125,28 @@ export function GraphView() {
   const rf = React.useRef<ReactFlowInstance | null>(null);
   const center = React.useCallback(() => rf.current?.fitView({ padding: 0.2, duration: 400 }), []);
 
+  // Closed beads dominate mature projects and zoom the fitted view out to
+  // illegibility, so the graph maps live work by default with closed opt-in.
+  const [showClosed, setShowClosed] = React.useState(false);
+
   const { nodes, edges } = React.useMemo(
-    () => layout(beads.filter((b) => !(b.labels ?? []).includes("archived")), openDetail),
-    [beads, openDetail],
+    () =>
+      layout(
+        beads.filter(
+          (b) =>
+            (showClosed || b.status !== "closed") && !(b.labels ?? []).includes("archived"),
+        ),
+        openDetail,
+      ),
+    [beads, showClosed, openDetail],
   );
+
+  // Toggling closed beads swaps most of the graph, so re-fit once the new
+  // nodes have painted.
+  React.useEffect(() => {
+    const t = setTimeout(() => rf.current?.fitView({ padding: 0.2, duration: 300 }), 50);
+    return () => clearTimeout(t);
+  }, [showClosed]);
 
   const onConnect = React.useCallback(
     (c: Connection) => {
@@ -138,6 +167,15 @@ export function GraphView() {
             (cycle-checked by bd)
           </span>
         </div>
+        <label className="flex h-9 flex-shrink-0 cursor-pointer items-center gap-[7px] rounded-[9px] border border-border bg-[var(--surface-2)] px-[12px] text-[12.5px] font-[550] text-[var(--text-2)] hover:bg-[var(--surface-3)]">
+          <input
+            type="checkbox"
+            checked={showClosed}
+            onChange={(e) => setShowClosed(e.target.checked)}
+            className="accent-[var(--brand)]"
+          />
+          <span>Show closed</span>
+        </label>
         <button
           onClick={center}
           title="Center the graph on all issues"
@@ -156,6 +194,9 @@ export function GraphView() {
           onInit={(inst) => {
             rf.current = inst;
           }}
+          // Large graphs (hundreds of beads) need a much lower zoom floor than
+          // React Flow's 0.5 default, or fitView can't pull the whole graph into frame.
+          minZoom={0.02}
           fitView
           proOptions={{ hideAttribution: true }}
         >


### PR DESCRIPTION
Stacked on #41 (includes its commit; rebases cleanly once #41 merges).

## Problem

Impact analysis only works in one direction today. The drawer shows what a bead depends on, but the reverse — **what closing this bead unblocks** — lives on other beads' edges and is invisible from the bead itself. And the graph offers no way to isolate one bead's dependency chains from the rest of the project.

## What this adds

**Drawer — "Blocks" section.** A read-only list of every bead whose dependency edge points at the open bead (blocking deps flagged `blocked by this` in red, `related` neutral), with status dot and click-through. Only rendered when dependents exist. It's read-only because the edge belongs to the other bead — click through to manage it.

**Graph — neighborhood spotlight.** Clicking a node computes the transitive upstream chain (what it waits on) and downstream chain (what waits on it) and dims everything else to 12%. The focused node gets a brand outline; a header chip shows `<id> ↑N · ↓M` and clears the spotlight, as does clicking the pane. Composes with the node click's existing open-drawer behavior — you get the detail panel and the highlighted chains in one click.

## Testing

- Verified on a real bd workspace (~900 beads): clicking a bead with a blocker outlines it and dims the rest; a bead that gates another lists it under Blocks with click-through.
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add downstream dependency visibility in the bead drawer and introduce a dependency-focused spotlight mode in the graph view.

New Features:
- Show a read-only Blocks section in the bead detail drawer listing beads that depend on the current bead, with status and click-through.
- Add a graph neighborhood spotlight that highlights the transitive upstream and downstream chains for a selected bead and dims unrelated nodes.
- Provide a graph control to toggle inclusion of closed beads in the visualization.

Enhancements:
- Prevent duplicate bead nodes in the graph layout and wrap loose beads into a grid for a more screen-friendly aspect ratio.
- Automatically refit the graph view when toggling closed beads to keep the layout legible.
- Lower the minimum zoom level in the graph to ensure large workspaces can fit into view.