### PR TITLE
feat(graph): epic scope with left-to-right dependency layout

### DIFF
--- a/components/bead-detail-drawer.tsx
+++ b/components/bead-detail-drawer.tsx
@@ -223,6 +223,17 @@ function DrawerBody({
   // epicProgress is parent-agnostic despite the name (worth renaming later).
   const kidProgress = epicProgress(bead.id, beads);
   const deps = (bead.dependencies ?? []).filter((d) => d.type !== "parent-child");
+  // The reverse direction: beads whose dependency edges point AT this one —
+  // i.e. what closing this bead unblocks. The edge lives on the other bead,
+  // so this is the only place downstream impact is visible.
+  const dependents = beads
+    .map((b) => ({
+      bead: b,
+      dep: (b.dependencies ?? []).find(
+        (d) => d.depends_on_id === bead.id && d.type !== "parent-child",
+      ),
+    }))
+    .filter((x): x is { bead: Bead; dep: NonNullable<typeof x.dep> } => !!x.dep);
   const notes = bead.notes?.trim() ?? "";
   const design = bead.design?.trim() ?? "";
   const acceptance = bead.acceptance_criteria?.trim() ?? "";
@@ -740,6 +751,49 @@ function DrawerBody({
               ))}
           </div>
         </Section>
+
+        {/* Downstream: beads waiting on this one. The edge lives on the other
+            bead, so it is read-only here — click through to manage it. */}
+        {dependents.length > 0 && (
+          <Section>
+            <Header icon="milestone" label="Blocks" count={dependents.length} />
+            <div className="flex flex-col gap-[7px]">
+              {dependents.map(({ bead: t, dep }) => {
+                const blocking = BLOCKING_DEP_TYPES.includes(dep.type as DepType);
+                const c = blocking ? "#ef4444" : "var(--text-2)";
+                return (
+                  <button
+                    key={t.id}
+                    onClick={() => pushDetail(t.id)}
+                    className="flex items-center gap-[9px] rounded-[9px] border border-border bg-[var(--surface)] p-[9px_11px] text-left hover:border-[var(--border-strong)]"
+                  >
+                    <span
+                      className="flex-shrink-0 rounded-[5px] px-[7px] py-[2px] font-mono text-[10px] font-semibold"
+                      style={{
+                        color: c,
+                        background: blocking ? "#ef444418" : "var(--surface-2)",
+                        border: `1px solid ${blocking ? "#ef444433" : "var(--border)"}`,
+                      }}
+                    >
+                      {blocking ? "blocked by this" : dep.type}
+                    </span>
+                    <span className="flex-shrink-0 font-mono text-[11px] text-[var(--text-3)]">
+                      {t.id}
+                    </span>
+                    <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
+                      {t.title}
+                    </span>
+                    <span
+                      className="h-[7px] w-[7px] flex-shrink-0 rounded-full"
+                      style={{ background: catColor(t.status) }}
+                      title={statusLabel(t.status)}
+                    />
+                  </button>
+                );
+              })}
+            </div>
+          </Section>
+        )}
 
         {/* Subtasks — one level deep, deliberately not recursive. */}
         <Section>

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -16,13 +16,39 @@ import "@xyflow/react/dist/style.css";
 import { Icon, typeIconName } from "@/components/icons";
 import { useApp } from "@/components/app-context";
 import { useAddDep } from "@/hooks/use-beads";
-import { catColor, typeColor, childrenOf } from "@/lib/beads-view";
+import { catColor, typeColor, childrenOf, childrenMap } from "@/lib/beads-view";
 import type { Bead } from "@/lib/schema";
 
-type BeadNodeData = { bead: Bead; onOpen: (id: string) => void; horizontal?: boolean };
+/** How many subtask lines a node shows before collapsing into "+N more". */
+const SUB_CAP = 4;
+const SUB_RANK: Record<string, number> = { in_progress: 0, hooked: 0, open: 1, deferred: 2 };
+
+/**
+ * Estimated node height (card + row gap) so layouts can space rows without
+ * overlap: ~19 chars of title per line at the card's 150px width, plus one
+ * small line per shown subtask.
+ */
+function nodeHeight(b: Bead, kids: number): number {
+  const titleLines = Math.min(6, Math.max(1, Math.ceil(b.title.length / 19)));
+  const subLines = kids ? Math.min(kids, SUB_CAP) + (kids > SUB_CAP ? 1 : 0) : 0;
+  return 58 + titleLines * 16 + (subLines ? 11 + subLines * 16 : 0) + 18;
+}
+
+type BeadNodeData = {
+  bead: Bead;
+  onOpen: (id: string) => void;
+  horizontal?: boolean;
+  subtasks?: Bead[];
+};
 
 function BeadNode({ data }: NodeProps) {
-  const { bead, onOpen, horizontal } = data as unknown as BeadNodeData;
+  const { bead, onOpen, horizontal, subtasks } = data as unknown as BeadNodeData;
+  const subs = subtasks?.length
+    ? [...subtasks].sort(
+        (a, b) =>
+          (SUB_RANK[a.status] ?? 3) - (SUB_RANK[b.status] ?? 3) || a.priority - b.priority,
+      )
+    : [];
   return (
     <div
       onClick={() => onOpen(bead.id)}
@@ -42,6 +68,31 @@ function BeadNode({ data }: NodeProps) {
       <div className="text-[12px] font-[550] leading-[1.3] text-[var(--text)] [text-wrap:pretty]">
         {bead.title.replace(/\s*\([^)]*\)\s*/, "")}
       </div>
+      {subs.length > 0 && (
+        <div className="mt-[6px] flex flex-col gap-[3px] border-t border-border pt-[5px]">
+          {subs.slice(0, SUB_CAP).map((k) => (
+            <div
+              key={k.id}
+              className="flex items-center gap-[5px]"
+              style={{ opacity: k.status === "closed" ? 0.55 : 1 }}
+              title={`${k.id} · ${k.title}`}
+            >
+              <span
+                className="h-[5px] w-[5px] flex-shrink-0 rounded-full"
+                style={{ background: catColor(k.status) }}
+              />
+              <span className="overflow-hidden text-ellipsis whitespace-nowrap text-[9.5px] leading-[1.35] text-[var(--text-2)]">
+                {k.title}
+              </span>
+            </div>
+          ))}
+          {subs.length > SUB_CAP && (
+            <div className="pl-[10px] text-[9px] text-[var(--text-3)]">
+              +{subs.length - SUB_CAP} more
+            </div>
+          )}
+        </div>
+      )}
       <Handle
         type="source"
         position={horizontal ? Position.Right : Position.Bottom}
@@ -53,7 +104,11 @@ function BeadNode({ data }: NodeProps) {
 
 const nodeTypes = { bead: BeadNode };
 
-function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; edges: Edge[] } {
+function layout(
+  beads: Bead[],
+  onOpen: (id: string) => void,
+  kids: Map<string, Bead[]>,
+): { nodes: Node[]; edges: Edge[] } {
   const present = new Set(beads.map((b) => b.id));
   const epics = beads.filter((b) => b.issue_type === "epic");
   const loose = beads.filter(
@@ -63,29 +118,27 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
   const nodes: Node[] = [];
   const seen = new Set<string>();
   // An epic can be both a column head and another epic's child; React Flow
-  // rejects duplicate node ids, so the first placement wins.
+  // rejects duplicate node ids, so the first placement wins. Rows advance by
+  // each node's own height — subtask lines make nodes unevenly tall.
   const push = (n: Node) => {
     if (seen.has(n.id)) return;
     seen.add(n.id);
     nodes.push(n);
   };
   const COL = 230;
-  const ROW = 116;
+  // Epic children are already drawn as the column below, so only non-epic
+  // nodes carry subtask lines — their children have no node of their own here.
+  const subsOf = (b: Bead) => (b.issue_type === "epic" ? undefined : kids.get(b.id));
+  const data = (b: Bead) => ({ bead: b, onOpen, subtasks: subsOf(b) });
+  const h = (b: Bead) => nodeHeight(b, subsOf(b)?.length ?? 0);
 
   epics.forEach((e, ci) => {
-    push({
-      id: e.id,
-      type: "bead",
-      position: { x: ci * COL, y: 0 },
-      data: { bead: e, onOpen },
-    });
-    childrenOf(e.id, beads).forEach((k, ri) => {
-      push({
-        id: k.id,
-        type: "bead",
-        position: { x: ci * COL, y: (ri + 1) * ROW },
-        data: { bead: k, onOpen },
-      });
+    let y = 0;
+    push({ id: e.id, type: "bead", position: { x: ci * COL, y }, data: data(e) });
+    y += h(e);
+    childrenOf(e.id, beads).forEach((k) => {
+      push({ id: k.id, type: "bead", position: { x: ci * COL, y }, data: data(k) });
+      y += h(k);
     });
   });
 
@@ -93,13 +146,16 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
   // fitted view stays near screen aspect ratio.
   const looseCol = epics.length;
   const WRAP = Math.max(6, Math.ceil(Math.sqrt(loose.length * 2)));
+  const looseY: number[] = [];
   loose.forEach((b, ri) => {
+    const col = Math.floor(ri / WRAP);
     push({
       id: b.id,
       type: "bead",
-      position: { x: (looseCol + Math.floor(ri / WRAP)) * COL, y: (ri % WRAP) * ROW },
-      data: { bead: b, onOpen },
+      position: { x: (looseCol + col) * COL, y: looseY[col] ?? 0 },
+      data: data(b),
     });
+    looseY[col] = (looseY[col] ?? 0) + h(b);
   });
 
   const placed = new Set(nodes.map((n) => n.id));
@@ -126,32 +182,21 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
   return { nodes, edges };
 }
 
-/** Every descendant of an epic, following parent-child edges through sub-epics. */
-function epicSubtree(epicId: string, beads: Bead[]): Bead[] {
-  const out: Bead[] = [];
-  const seen = new Set([epicId]);
-  const queue = [epicId];
-  while (queue.length) {
-    for (const k of childrenOf(queue.shift()!, beads)) {
-      if (seen.has(k.id)) continue;
-      seen.add(k.id);
-      out.push(k);
-      queue.push(k.id);
-    }
-  }
-  return out;
-}
-
 const BLOCKING = new Set(["blocks", "conditional-blocks", "waits-for"]);
 
 /**
- * Left-to-right layered layout for one epic's subtree: a bead's column is its
- * longest blocking-dependency chain, so unblocked work sits on the left and
- * downstream work flows right. Edges are drawn upstream -> downstream to read
- * in the same direction; parent-child edges are omitted (the tree structure is
- * the selection, not the flow).
+ * Left-to-right layered layout for one epic's direct children: a bead's column
+ * is its longest blocking-dependency chain, so unblocked work sits on the left
+ * and downstream work flows right. Each card rolls up its own subtasks as
+ * lines rather than spawning grandchild nodes, and edges are drawn
+ * upstream -> downstream to read in the same direction; parent-child edges are
+ * omitted (the tree structure is the selection, not the flow).
  */
-function epicLayout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; edges: Edge[] } {
+function epicLayout(
+  beads: Bead[],
+  onOpen: (id: string) => void,
+  kids: Map<string, Bead[]>,
+): { nodes: Node[]; edges: Edge[] } {
   const present = new Map(beads.map((b) => [b.id, b]));
   const depth = new Map<string, number>();
   const depthOf = (b: Bead, trail: Set<string>): number => {
@@ -178,19 +223,20 @@ function epicLayout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[
   }
 
   const COL = 250;
-  const ROW = 116;
   const nodes: Node[] = [];
   for (const d of [...layers.keys()].sort((a, b) => a - b)) {
+    let y = 0;
     layers
       .get(d)!
       .sort((a, b) => a.priority - b.priority || a.id.localeCompare(b.id))
-      .forEach((b, ri) => {
+      .forEach((b) => {
         nodes.push({
           id: b.id,
           type: "bead",
-          position: { x: d * COL, y: ri * ROW },
-          data: { bead: b, onOpen, horizontal: true },
+          position: { x: d * COL, y },
+          data: { bead: b, onOpen, horizontal: true, subtasks: kids.get(b.id) },
         });
+        y += nodeHeight(b, kids.get(b.id)?.length ?? 0);
       });
   }
 
@@ -241,8 +287,11 @@ export function GraphView() {
   const { nodes, edges } = React.useMemo(() => {
     const live = (b: Bead) =>
       (showClosed || b.status !== "closed") && !(b.labels ?? []).includes("archived");
-    if (epicId) return epicLayout(epicSubtree(epicId, beads).filter(live), openDetail);
-    return layout(beads.filter(live), openDetail);
+    // Subtask lines come from ALL beads, not the filtered set — a card should
+    // report finished children even when closed beads are hidden as nodes.
+    const kids = childrenMap(beads);
+    if (epicId) return epicLayout(childrenOf(epicId, beads).filter(live), openDetail, kids);
+    return layout(beads.filter(live), openDetail, kids);
   }, [beads, showClosed, epicId, openDetail]);
 
   // Toggling closed beads swaps most of the graph, so re-fit once the new

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -148,6 +148,53 @@ export function GraphView() {
     return () => clearTimeout(t);
   }, [showClosed]);
 
+  // Clicking a node spotlights its dependency neighborhood: the transitive
+  // upstream chain (what it waits on) and downstream chain (what waits on it).
+  // Everything else dims. Clicking the pane clears it.
+  const [focusId, setFocusId] = React.useState<string | null>(null);
+  const focus = React.useMemo(() => {
+    if (!focusId) return null;
+    const up = new Set([focusId]);
+    const down = new Set([focusId]);
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const e of edges) {
+        if (up.has(e.source) && !up.has(e.target)) {
+          up.add(e.target);
+          grew = true;
+        }
+        if (down.has(e.target) && !down.has(e.source)) {
+          down.add(e.source);
+          grew = true;
+        }
+      }
+    }
+    return { all: new Set([...up, ...down]), up: up.size - 1, down: down.size - 1 };
+  }, [focusId, edges]);
+
+  const shownNodes = React.useMemo(() => {
+    if (!focus) return nodes;
+    return nodes.map((n) => ({
+      ...n,
+      style: {
+        ...n.style,
+        opacity: focus.all.has(n.id) ? 1 : 0.12,
+        outline: n.id === focusId ? "2.5px solid var(--brand)" : undefined,
+        outlineOffset: n.id === focusId ? 3 : undefined,
+        borderRadius: 11,
+      },
+    }));
+  }, [nodes, focus, focusId]);
+
+  const shownEdges = React.useMemo(() => {
+    if (!focus) return edges;
+    return edges.map((e) => {
+      const lit = focus.all.has(e.source) && focus.all.has(e.target);
+      return { ...e, style: { ...e.style, opacity: lit ? 1 : 0.05 }, animated: lit && e.animated };
+    });
+  }, [edges, focus]);
+
   const onConnect = React.useCallback(
     (c: Connection) => {
       if (c.source && c.target && c.source !== c.target) {
@@ -167,6 +214,20 @@ export function GraphView() {
             (cycle-checked by bd)
           </span>
         </div>
+        {focus && focusId && (
+          <button
+            onClick={() => setFocusId(null)}
+            title="Clear the neighborhood spotlight"
+            className="flex h-9 flex-shrink-0 items-center gap-[7px] rounded-[9px] px-[12px] text-[12.5px] font-[550] text-[var(--brand)]"
+            style={{ background: "var(--brand-weak)" }}
+          >
+            <span className="font-mono">{focusId}</span>
+            <span className="text-[11.5px] opacity-80">
+              ↑{focus.up} · ↓{focus.down}
+            </span>
+            <Icon name="x" size={13} />
+          </button>
+        )}
         <label className="flex h-9 flex-shrink-0 cursor-pointer items-center gap-[7px] rounded-[9px] border border-border bg-[var(--surface-2)] px-[12px] text-[12.5px] font-[550] text-[var(--text-2)] hover:bg-[var(--surface-3)]">
           <input
             type="checkbox"
@@ -187,10 +248,12 @@ export function GraphView() {
       </header>
       <div className="relative min-h-0 flex-1">
         <ReactFlow
-          nodes={nodes}
-          edges={edges}
+          nodes={shownNodes}
+          edges={shownEdges}
           nodeTypes={nodeTypes}
           onConnect={onConnect}
+          onNodeClick={(_, n) => setFocusId(n.id)}
+          onPaneClick={() => setFocusId(null)}
           onInit={(inst) => {
             rf.current = inst;
           }}

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -19,16 +19,20 @@ import { useAddDep } from "@/hooks/use-beads";
 import { catColor, typeColor, childrenOf } from "@/lib/beads-view";
 import type { Bead } from "@/lib/schema";
 
-type BeadNodeData = { bead: Bead; onOpen: (id: string) => void };
+type BeadNodeData = { bead: Bead; onOpen: (id: string) => void; horizontal?: boolean };
 
 function BeadNode({ data }: NodeProps) {
-  const { bead, onOpen } = data as unknown as BeadNodeData;
+  const { bead, onOpen, horizontal } = data as unknown as BeadNodeData;
   return (
     <div
       onClick={() => onOpen(bead.id)}
       className="w-[150px] cursor-pointer rounded-[11px] border border-border bg-[var(--surface)] p-[9px_11px] shadow-[var(--shadow)] hover:border-[var(--border-strong)] hover:shadow-[var(--shadow-lg)]"
     >
-      <Handle type="target" position={Position.Top} style={{ background: "var(--text-3)" }} />
+      <Handle
+        type="target"
+        position={horizontal ? Position.Left : Position.Top}
+        style={{ background: "var(--text-3)" }}
+      />
       <div className="mb-[5px] flex items-center gap-[6px]">
         <span className="h-2 w-2 rounded-full" style={{ background: catColor(bead.status) }} />
         <span className="font-mono text-[10.5px] text-[var(--text-3)]">{bead.id}</span>
@@ -38,7 +42,11 @@ function BeadNode({ data }: NodeProps) {
       <div className="text-[12px] font-[550] leading-[1.3] text-[var(--text)] [text-wrap:pretty]">
         {bead.title.replace(/\s*\([^)]*\)\s*/, "")}
       </div>
-      <Handle type="source" position={Position.Bottom} style={{ background: "var(--text-3)" }} />
+      <Handle
+        type="source"
+        position={horizontal ? Position.Right : Position.Bottom}
+        style={{ background: "var(--text-3)" }}
+      />
     </div>
   );
 }
@@ -118,6 +126,96 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
   return { nodes, edges };
 }
 
+/** Every descendant of an epic, following parent-child edges through sub-epics. */
+function epicSubtree(epicId: string, beads: Bead[]): Bead[] {
+  const out: Bead[] = [];
+  const seen = new Set([epicId]);
+  const queue = [epicId];
+  while (queue.length) {
+    for (const k of childrenOf(queue.shift()!, beads)) {
+      if (seen.has(k.id)) continue;
+      seen.add(k.id);
+      out.push(k);
+      queue.push(k.id);
+    }
+  }
+  return out;
+}
+
+const BLOCKING = new Set(["blocks", "conditional-blocks", "waits-for"]);
+
+/**
+ * Left-to-right layered layout for one epic's subtree: a bead's column is its
+ * longest blocking-dependency chain, so unblocked work sits on the left and
+ * downstream work flows right. Edges are drawn upstream -> downstream to read
+ * in the same direction; parent-child edges are omitted (the tree structure is
+ * the selection, not the flow).
+ */
+function epicLayout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; edges: Edge[] } {
+  const present = new Map(beads.map((b) => [b.id, b]));
+  const depth = new Map<string, number>();
+  const depthOf = (b: Bead, trail: Set<string>): number => {
+    const known = depth.get(b.id);
+    if (known !== undefined) return known;
+    if (trail.has(b.id)) return 0;
+    trail.add(b.id);
+    const blockers = (b.dependencies ?? []).filter(
+      (d) => BLOCKING.has(d.type) && present.has(d.depends_on_id),
+    );
+    const d = blockers.length
+      ? 1 + Math.max(...blockers.map((x) => depthOf(present.get(x.depends_on_id)!, trail)))
+      : 0;
+    depth.set(b.id, d);
+    return d;
+  };
+  for (const b of beads) depthOf(b, new Set());
+
+  const layers = new Map<number, Bead[]>();
+  for (const b of beads) {
+    const d = depth.get(b.id) ?? 0;
+    if (!layers.has(d)) layers.set(d, []);
+    layers.get(d)!.push(b);
+  }
+
+  const COL = 250;
+  const ROW = 116;
+  const nodes: Node[] = [];
+  for (const d of [...layers.keys()].sort((a, b) => a - b)) {
+    layers
+      .get(d)!
+      .sort((a, b) => a.priority - b.priority || a.id.localeCompare(b.id))
+      .forEach((b, ri) => {
+        nodes.push({
+          id: b.id,
+          type: "bead",
+          position: { x: d * COL, y: ri * ROW },
+          data: { bead: b, onOpen, horizontal: true },
+        });
+      });
+  }
+
+  const edges: Edge[] = [];
+  for (const b of beads) {
+    for (const d of b.dependencies ?? []) {
+      if (d.type === "parent-child" || !present.has(d.depends_on_id)) continue;
+      const blocking = BLOCKING.has(d.type);
+      const related = d.type === "related" || d.type === "relates-to";
+      edges.push({
+        id: `${d.depends_on_id}->${b.id}:${d.type}`,
+        source: d.depends_on_id,
+        target: b.id,
+        animated: blocking,
+        style: {
+          stroke: blocking ? "#ef4444" : related ? "var(--brand)" : "var(--text-3)",
+          strokeWidth: blocking ? 2 : 1.6,
+          strokeDasharray: related ? "5 4" : undefined,
+        },
+      });
+    }
+  }
+  return { nodes, edges };
+}
+
 export function GraphView() {
   const { beads, openDetail } = useApp();
   const addDep = useAddDep();
@@ -129,24 +227,30 @@ export function GraphView() {
   // illegibility, so the graph maps live work by default with closed opt-in.
   const [showClosed, setShowClosed] = React.useState(false);
 
-  const { nodes, edges } = React.useMemo(
+  // "" = the whole project (column-per-epic layout); an epic id switches to
+  // that epic's subtree, layered left-to-right by dependency depth.
+  const [epicId, setEpicId] = React.useState("");
+  const epics = React.useMemo(
     () =>
-      layout(
-        beads.filter(
-          (b) =>
-            (showClosed || b.status !== "closed") && !(b.labels ?? []).includes("archived"),
-        ),
-        openDetail,
-      ),
-    [beads, showClosed, openDetail],
+      beads
+        .filter((b) => b.issue_type === "epic" && b.status !== "closed")
+        .sort((a, b) => a.priority - b.priority || a.id.localeCompare(b.id)),
+    [beads],
   );
+
+  const { nodes, edges } = React.useMemo(() => {
+    const live = (b: Bead) =>
+      (showClosed || b.status !== "closed") && !(b.labels ?? []).includes("archived");
+    if (epicId) return epicLayout(epicSubtree(epicId, beads).filter(live), openDetail);
+    return layout(beads.filter(live), openDetail);
+  }, [beads, showClosed, epicId, openDetail]);
 
   // Toggling closed beads swaps most of the graph, so re-fit once the new
   // nodes have painted.
   React.useEffect(() => {
     const t = setTimeout(() => rf.current?.fitView({ padding: 0.2, duration: 300 }), 50);
     return () => clearTimeout(t);
-  }, [showClosed]);
+  }, [showClosed, epicId]);
 
   // Clicking a node spotlights its dependency neighborhood: the transitive
   // upstream chain (what it waits on) and downstream chain (what waits on it).
@@ -154,24 +258,28 @@ export function GraphView() {
   const [focusId, setFocusId] = React.useState<string | null>(null);
   const focus = React.useMemo(() => {
     if (!focusId) return null;
+    // Edge orientation flips in epic mode (drawn upstream -> downstream there,
+    // dependent -> dependency otherwise), so normalize before walking.
+    const dependent = (e: Edge) => (epicId ? e.target : e.source);
+    const dependency = (e: Edge) => (epicId ? e.source : e.target);
     const up = new Set([focusId]);
     const down = new Set([focusId]);
     let grew = true;
     while (grew) {
       grew = false;
       for (const e of edges) {
-        if (up.has(e.source) && !up.has(e.target)) {
-          up.add(e.target);
+        if (up.has(dependent(e)) && !up.has(dependency(e))) {
+          up.add(dependency(e));
           grew = true;
         }
-        if (down.has(e.target) && !down.has(e.source)) {
-          down.add(e.source);
+        if (down.has(dependency(e)) && !down.has(dependent(e))) {
+          down.add(dependent(e));
           grew = true;
         }
       }
     }
     return { all: new Set([...up, ...down]), up: up.size - 1, down: down.size - 1 };
-  }, [focusId, edges]);
+  }, [focusId, edges, epicId]);
 
   const shownNodes = React.useMemo(() => {
     if (!focus) return nodes;
@@ -197,11 +305,13 @@ export function GraphView() {
 
   const onConnect = React.useCallback(
     (c: Connection) => {
-      if (c.source && c.target && c.source !== c.target) {
-        addDep.mutate({ id: c.source, dependsOnId: c.target, type: "blocks" });
-      }
+      if (!c.source || !c.target || c.source === c.target) return;
+      // Epic mode draws upstream -> downstream, so the dragged edge's TARGET is
+      // the bead that gains the dependency.
+      const [id, dependsOnId] = epicId ? [c.target, c.source] : [c.source, c.target];
+      addDep.mutate({ id, dependsOnId, type: "blocks" });
     },
-    [addDep],
+    [addDep, epicId],
   );
 
   return (
@@ -210,10 +320,32 @@ export function GraphView() {
         <div className="flex-1">
           <h1 className="m-0 text-base font-[650] tracking-[-.01em]">Dependency graph</h1>
           <span className="text-[11.5px] text-[var(--text-3)]">
-            <span className="font-mono">bd dep tree</span> · drag a node handle onto another to link
-            (cycle-checked by bd)
+            {epicId ? (
+              <>left → right = dependency order · drag upstream onto downstream to link</>
+            ) : (
+              <>
+                <span className="font-mono">bd dep tree</span> · drag a node handle onto another
+                to link (cycle-checked by bd)
+              </>
+            )}
           </span>
         </div>
+        <select
+          value={epicId}
+          onChange={(e) => {
+            setEpicId(e.target.value);
+            setFocusId(null);
+          }}
+          title="Scope the graph to one epic's subtree"
+          className="h-9 max-w-[280px] flex-shrink-0 cursor-pointer rounded-[9px] border border-border bg-[var(--surface-2)] px-[10px] text-[12.5px] font-[550] text-[var(--text-2)] outline-none hover:bg-[var(--surface-3)]"
+        >
+          <option value="">All epics</option>
+          {epics.map((e) => (
+            <option key={e.id} value={e.id}>
+              {e.id} · {e.title.slice(0, 40)}
+            </option>
+          ))}
+        </select>
         {focus && focusId && (
           <button
             onClick={() => setFocusId(null)}

--- a/components/graph-view.tsx
+++ b/components/graph-view.tsx
@@ -53,18 +53,26 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
   );
 
   const nodes: Node[] = [];
+  const seen = new Set<string>();
+  // An epic can be both a column head and another epic's child; React Flow
+  // rejects duplicate node ids, so the first placement wins.
+  const push = (n: Node) => {
+    if (seen.has(n.id)) return;
+    seen.add(n.id);
+    nodes.push(n);
+  };
   const COL = 230;
   const ROW = 116;
 
   epics.forEach((e, ci) => {
-    nodes.push({
+    push({
       id: e.id,
       type: "bead",
       position: { x: ci * COL, y: 0 },
       data: { bead: e, onOpen },
     });
     childrenOf(e.id, beads).forEach((k, ri) => {
-      nodes.push({
+      push({
         id: k.id,
         type: "bead",
         position: { x: ci * COL, y: (ri + 1) * ROW },
@@ -73,12 +81,15 @@ function layout(beads: Bead[], onOpen: (id: string) => void): { nodes: Node[]; e
     });
   });
 
+  // Wrap the loose beads into a grid instead of one endless column, so the
+  // fitted view stays near screen aspect ratio.
   const looseCol = epics.length;
+  const WRAP = Math.max(6, Math.ceil(Math.sqrt(loose.length * 2)));
   loose.forEach((b, ri) => {
-    nodes.push({
+    push({
       id: b.id,
       type: "bead",
-      position: { x: looseCol * COL, y: ri * ROW },
+      position: { x: (looseCol + Math.floor(ri / WRAP)) * COL, y: (ri % WRAP) * ROW },
       data: { bead: b, onOpen },
     });
   });
@@ -114,10 +125,28 @@ export function GraphView() {
   const rf = React.useRef<ReactFlowInstance | null>(null);
   const center = React.useCallback(() => rf.current?.fitView({ padding: 0.2, duration: 400 }), []);
 
+  // Closed beads dominate mature projects and zoom the fitted view out to
+  // illegibility, so the graph maps live work by default with closed opt-in.
+  const [showClosed, setShowClosed] = React.useState(false);
+
   const { nodes, edges } = React.useMemo(
-    () => layout(beads.filter((b) => !(b.labels ?? []).includes("archived")), openDetail),
-    [beads, openDetail],
+    () =>
+      layout(
+        beads.filter(
+          (b) =>
+            (showClosed || b.status !== "closed") && !(b.labels ?? []).includes("archived"),
+        ),
+        openDetail,
+      ),
+    [beads, showClosed, openDetail],
   );
+
+  // Toggling closed beads swaps most of the graph, so re-fit once the new
+  // nodes have painted.
+  React.useEffect(() => {
+    const t = setTimeout(() => rf.current?.fitView({ padding: 0.2, duration: 300 }), 50);
+    return () => clearTimeout(t);
+  }, [showClosed]);
 
   const onConnect = React.useCallback(
     (c: Connection) => {
@@ -138,6 +167,15 @@ export function GraphView() {
             (cycle-checked by bd)
           </span>
         </div>
+        <label className="flex h-9 flex-shrink-0 cursor-pointer items-center gap-[7px] rounded-[9px] border border-border bg-[var(--surface-2)] px-[12px] text-[12.5px] font-[550] text-[var(--text-2)] hover:bg-[var(--surface-3)]">
+          <input
+            type="checkbox"
+            checked={showClosed}
+            onChange={(e) => setShowClosed(e.target.checked)}
+            className="accent-[var(--brand)]"
+          />
+          <span>Show closed</span>
+        </label>
         <button
           onClick={center}
           title="Center the graph on all issues"
@@ -156,6 +194,9 @@ export function GraphView() {
           onInit={(inst) => {
             rf.current = inst;
           }}
+          // Large graphs (hundreds of beads) need a much lower zoom floor than
+          // React Flow's 0.5 default, or fitView can't pull the whole graph into frame.
+          minZoom={0.02}
           fitView
           proOptions={{ hideAttribution: true }}
         >

--- a/lib/beads-view.ts
+++ b/lib/beads-view.ts
@@ -213,6 +213,19 @@ export function childrenCountMap(beads: Bead[]): Map<string, number> {
   return m;
 }
 
+/** Children per parent id in ONE pass — the Bead[] sibling of childrenCountMap. */
+export function childrenMap(beads: Bead[]): Map<string, Bead[]> {
+  const m = new Map<string, Bead[]>();
+  for (const b of beads) {
+    for (const d of b.dependencies ?? []) {
+      if (d.type !== "parent-child") continue;
+      if (!m.has(d.depends_on_id)) m.set(d.depends_on_id, []);
+      m.get(d.depends_on_id)!.push(b);
+    }
+  }
+  return m;
+}
+
 export function childrenOf(epicId: string, beads: Bead[]): Bead[] {
   return beads.filter((b) =>
     (b.dependencies ?? []).some(


### PR DESCRIPTION
Stacked on #43 (includes its commits; rebases cleanly as the stack merges).

## Problem

The whole-project graph answers *what does the system look like*, not *how is this epic going*. There's no way to isolate one epic's work, and the column layout doesn't express execution order.

## What this adds

An **epic dropdown** in the graph header. "All epics" keeps the existing project-wide layout; picking an epic scopes the graph to that epic's subtree (children collected recursively through sub-epics).

In epic mode the layout switches to **layered left→right dependency flow**:

- A bead's column is its longest blocking-dependency chain: unblocked work sits in the leftmost column, downstream work flows right.
- Node handles turn horizontal and edges draw **upstream → downstream**, so the arrows read in the same direction as execution.
- Parent-child edges are omitted — the tree is the *selection*, not the flow. Blocking edges stay red/animated, related stay dashed.
- Drag-to-link and the neighborhood spotlight (#43) are direction-aware in both modes; switching epics clears the spotlight and re-fits the view.

## Testing

- Verified on a real bd workspace: selecting an epic renders only its subtree, with its one cross-bead blocker correctly pushed one column right of the bead it waits on and the edge flowing left→right.
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add epic-scoped, left-to-right dependency visualization to the graph view and expose downstream blockers in bead details.

New Features:
- Introduce an epic selector that scopes the dependency graph to a single epic's subtree.
- Add a left-to-right layered layout for epic graphs with horizontal node handles and direction-aware edge creation.
- Add a neighborhood spotlight mode that highlights a bead's upstream and downstream dependency chains in the graph.
- Expose beads that are blocked by the current bead in the detail drawer via a read-only Blocks section.

Enhancements:
- Rework default graph filtering to hide closed beads by default with an option to show them and auto-refit the view on scope changes.
- Improve loose bead placement in the whole-project layout to keep the fitted view closer to screen aspect ratio.
- Handle duplicate epic nodes safely in the graph layout and allow deeper zoom-out levels for large graphs.